### PR TITLE
Support legacy events

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,5 +6,5 @@ build:
 wrap:
 	docker compose run transformer python scripts/wrap_tables.py
 
-dbt:
+dbt: build
 	docker compose run transformer dbt run --target base_goerli --profiles-dir profiles --profile docker

--- a/indexers/base-goerli/abi/PerpsMarketProxy.json
+++ b/indexers/base-goerli/abi/PerpsMarketProxy.json
@@ -3158,6 +3158,11 @@
             "internalType": "bool",
             "name": "disabled",
             "type": "bool"
+          },
+          {
+            "internalType": "uint256",
+            "name": "commitmentPriceDelay",
+            "type": "uint256"
           }
         ],
         "indexed": false,
@@ -3226,6 +3231,11 @@
             "internalType": "bool",
             "name": "disabled",
             "type": "bool"
+          },
+          {
+            "internalType": "uint256",
+            "name": "commitmentPriceDelay",
+            "type": "uint256"
           }
         ],
         "indexed": false,
@@ -3280,6 +3290,11 @@
             "internalType": "bool",
             "name": "disabled",
             "type": "bool"
+          },
+          {
+            "internalType": "uint256",
+            "name": "commitmentPriceDelay",
+            "type": "uint256"
           }
         ],
         "internalType": "struct SettlementStrategy.Data",
@@ -3532,6 +3547,11 @@
             "internalType": "bool",
             "name": "disabled",
             "type": "bool"
+          },
+          {
+            "internalType": "uint256",
+            "name": "commitmentPriceDelay",
+            "type": "uint256"
           }
         ],
         "internalType": "struct SettlementStrategy.Data",
@@ -3743,6 +3763,11 @@
             "internalType": "bool",
             "name": "disabled",
             "type": "bool"
+          },
+          {
+            "internalType": "uint256",
+            "name": "commitmentPriceDelay",
+            "type": "uint256"
           }
         ],
         "internalType": "struct SettlementStrategy.Data",

--- a/indexers/base-goerli/abi/PerpsMarketProxy.json
+++ b/indexers/base-goerli/abi/PerpsMarketProxy.json
@@ -1799,6 +1799,12 @@
       {
         "indexed": false,
         "internalType": "uint256",
+        "name": "expectedPriceTime",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
         "name": "settlementTime",
         "type": "uint256"
       },

--- a/indexers/base-goerli/abi/PerpsMarketProxyLegacy.json
+++ b/indexers/base-goerli/abi/PerpsMarketProxyLegacy.json
@@ -1,0 +1,69 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint128",
+        "name": "marketId",
+        "type": "uint128"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint128",
+        "name": "accountId",
+        "type": "uint128"
+      },
+      {
+        "indexed": false,
+        "internalType": "enum SettlementStrategy.Type",
+        "name": "orderType",
+        "type": "uint8"
+      },
+      {
+        "indexed": false,
+        "internalType": "int128",
+        "name": "sizeDelta",
+        "type": "int128"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "acceptablePrice",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "commitmentTime",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "settlementTime",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "expirationTime",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "trackingCode",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      }
+    ],
+    "name": "OrderCommitted",
+    "type": "event"
+  }
+]

--- a/indexers/base-goerli/squidgen.yaml
+++ b/indexers/base-goerli/squidgen.yaml
@@ -26,6 +26,11 @@ contracts:
     abi: ./abi/PerpsMarketProxy.json
     events: true
     functions: false
+  - name: PerpsMarketProxyLegacy
+    address: "0x75c43165ea38cB857C45216a37C5405A7656673c"
+    abi: ./abi/PerpsMarketProxyLegacy.json
+    events: true
+    functions: false
   - name: SpotMarketProxy
     address: "0x26f3EcFa0Aa924649cfd4b74C57637e910A983a4"
     abi: ./abi/SpotMarketProxy.json

--- a/transformers/synthetix/models/raw/perp/perp_order_committed.sql
+++ b/transformers/synthetix/models/raw/perp/perp_order_committed.sql
@@ -1,4 +1,55 @@
-{{ get_event_data(
-    'perps_market_proxy',
-    'order_committed'
-) }}
+WITH legacy_events AS (
+    {{ get_event_data(
+        'perps_market_proxy_legacy',
+        'order_committed'
+    ) }}
+),
+current_events AS (
+    {{ get_event_data(
+        'perps_market_proxy',
+        'order_committed'
+    ) }}
+)
+SELECT
+    id,
+    block_number,
+    block_timestamp,
+    transaction_hash,
+    "contract",
+    event_name,
+    market_id,
+    account_id,
+    commitment_time,
+    expiration_time,
+    settlement_time,
+    CAST(
+        NULL AS numeric
+    ) AS expected_price_time,
+    acceptable_price,
+    order_type,
+    size_delta,
+    sender,
+    tracking_code
+FROM
+    legacy_events
+UNION ALL
+SELECT
+    id,
+    block_number,
+    block_timestamp,
+    transaction_hash,
+    "contract",
+    event_name,
+    market_id,
+    account_id,
+    commitment_time,
+    expiration_time,
+    settlement_time,
+    expected_price_time,
+    acceptable_price,
+    order_type,
+    size_delta,
+    sender,
+    tracking_code
+FROM
+    current_events

--- a/transformers/synthetix/models/raw/sources.yml
+++ b/transformers/synthetix/models/raw/sources.yml
@@ -11,6 +11,7 @@ sources:
       - name: perps_market_proxy_event_market_created
       - name: perps_market_proxy_event_market_updated
       - name: perps_market_proxy_event_order_committed
+      - name: perps_market_proxy_legacy_event_order_committed
       - name: perps_market_proxy_event_order_settled
       - name: perps_market_proxy_event_position_liquidated
       - name: perps_market_proxy_event_previous_order_expired


### PR DESCRIPTION
Support a deprecated event from an old contract version with a `Legacy` ABI. Add to transforms to handle the combination of legacy events with current ones