### PR TITLE
Skew charts

### DIFF
--- a/dashboard/modules/base_mainnet/core_stats.py
+++ b/dashboard/modules/base_mainnet/core_stats.py
@@ -13,7 +13,7 @@ filters = {
 
 
 ## data
-@st.cache_data(ttl=1)
+@st.cache_data(ttl=600)
 def fetch_data(filters):
     # get filters
     start_date = filters["start_date"]

--- a/dashboard/modules/base_mainnet/perp_account.py
+++ b/dashboard/modules/base_mainnet/perp_account.py
@@ -15,7 +15,7 @@ filters = {
 
 
 ## data
-@st.cache_data(ttl=1)
+@st.cache_data(ttl=600)
 def fetch_data(filters):
     # get filters
     account_id = filters["account_id"]
@@ -139,7 +139,6 @@ def fetch_data(filters):
     }
 
 
-@st.cache_data(ttl=1)
 def make_charts(data):
     return {
         "cumulative_volume": chart_lines(

--- a/dashboard/modules/base_mainnet/perp_integrators.py
+++ b/dashboard/modules/base_mainnet/perp_integrators.py
@@ -15,7 +15,7 @@ filters = {
 
 
 ## data
-@st.cache_data(ttl=1)
+@st.cache_data(ttl=600)
 def fetch_data(filters):
     # get filters
     start_date = filters["start_date"]
@@ -51,7 +51,6 @@ def fetch_data(filters):
     }
 
 
-@st.cache_data(ttl=1)
 def make_charts(data):
     return {
         "accounts": chart_bars(

--- a/dashboard/modules/base_mainnet/perp_keepers.py
+++ b/dashboard/modules/base_mainnet/perp_keepers.py
@@ -14,7 +14,7 @@ filters = {
 
 
 ## data
-@st.cache_data(ttl=1)
+@st.cache_data(ttl=600)
 def fetch_data(filters):
     # get filters
     start_date = filters["start_date"]

--- a/dashboard/modules/base_mainnet/perp_markets.py
+++ b/dashboard/modules/base_mainnet/perp_markets.py
@@ -13,7 +13,7 @@ filters = {
 
 
 ## data
-@st.cache_data(ttl=1)
+@st.cache_data(ttl=600)
 def fetch_data(filters):
     # get filters
     start_date = filters["start_date"]

--- a/dashboard/modules/base_mainnet/perp_stats.py
+++ b/dashboard/modules/base_mainnet/perp_stats.py
@@ -15,7 +15,7 @@ filters = {
 
 
 ## data
-@st.cache_data(ttl=1)
+@st.cache_data(ttl=600)
 def fetch_data(filters):
     # get filters
     start_date = filters["start_date"]
@@ -65,7 +65,6 @@ def fetch_data(filters):
     }
 
 
-@st.cache_data(ttl=1)
 def make_charts(data):
     return {
         "volume": chart_bars(data["stats"], "ts", ["volume"], "Volume"),

--- a/dashboard/modules/base_mainnet/spot_markets.py
+++ b/dashboard/modules/base_mainnet/spot_markets.py
@@ -14,7 +14,7 @@ filters = {
 
 
 ## data
-@st.cache_data(ttl=1)
+@st.cache_data(ttl=600)
 def fetch_data(settings):
     # get filters
     start_date = filters["start_date"]
@@ -74,7 +74,6 @@ def fetch_data(settings):
     }
 
 
-@st.cache_data(ttl=1)
 def make_charts(data):
     return {
         "supply": chart_lines(

--- a/dashboard/modules/base_sepolia/core_stats.py
+++ b/dashboard/modules/base_sepolia/core_stats.py
@@ -13,7 +13,7 @@ filters = {
 
 
 ## data
-@st.cache_data(ttl=1)
+@st.cache_data(ttl=600)
 def fetch_data(filters):
     # get filters
     start_date = filters["start_date"]

--- a/dashboard/modules/base_sepolia/perp_account.py
+++ b/dashboard/modules/base_sepolia/perp_account.py
@@ -15,7 +15,7 @@ filters = {
 
 
 ## data
-@st.cache_data(ttl=1)
+@st.cache_data(ttl=600)
 def fetch_data(filters):
     # get filters
     account_id = filters["account_id"]
@@ -139,7 +139,6 @@ def fetch_data(filters):
     }
 
 
-@st.cache_data(ttl=1)
 def make_charts(data):
     return {
         "cumulative_volume": chart_lines(

--- a/dashboard/modules/base_sepolia/perp_integrators.py
+++ b/dashboard/modules/base_sepolia/perp_integrators.py
@@ -15,7 +15,7 @@ filters = {
 
 
 ## data
-@st.cache_data(ttl=1)
+@st.cache_data(ttl=600)
 def fetch_data(filters):
     # get filters
     start_date = filters["start_date"]
@@ -51,7 +51,6 @@ def fetch_data(filters):
     }
 
 
-@st.cache_data(ttl=1)
 def make_charts(data):
     return {
         "accounts": chart_bars(

--- a/dashboard/modules/base_sepolia/perp_keepers.py
+++ b/dashboard/modules/base_sepolia/perp_keepers.py
@@ -14,7 +14,7 @@ filters = {
 
 
 ## data
-@st.cache_data(ttl=1)
+@st.cache_data(ttl=600)
 def fetch_data(filters):
     # get filters
     start_date = filters["start_date"]

--- a/dashboard/modules/base_sepolia/perp_markets.py
+++ b/dashboard/modules/base_sepolia/perp_markets.py
@@ -13,7 +13,7 @@ filters = {
 
 
 ## data
-@st.cache_data(ttl=1)
+@st.cache_data(ttl=600)
 def fetch_data(filters):
     # get filters
     start_date = filters["start_date"]

--- a/dashboard/modules/base_sepolia/perp_monitor.py
+++ b/dashboard/modules/base_sepolia/perp_monitor.py
@@ -15,7 +15,7 @@ filters = {
 
 
 ## data
-@st.cache_data(ttl=1)
+@st.cache_data(ttl=60)
 def fetch_data(filters):
     # get filters
     start_date = filters["start_date"]
@@ -113,7 +113,6 @@ def fetch_data(filters):
     }
 
 
-@st.cache_data(ttl=1)
 def make_charts(data):
     return {
         "volume": chart_bars(

--- a/dashboard/modules/base_sepolia/perp_stats.py
+++ b/dashboard/modules/base_sepolia/perp_stats.py
@@ -15,7 +15,7 @@ filters = {
 
 
 ## data
-@st.cache_data(ttl=1)
+@st.cache_data(ttl=600)
 def fetch_data(filters):
     # get filters
     start_date = filters["start_date"]
@@ -50,7 +50,6 @@ def fetch_data(filters):
     }
 
 
-@st.cache_data(ttl=1)
 def make_charts(data):
     return {
         "volume": chart_bars(data["stats"], "ts", ["volume"], "Volume"),

--- a/dashboard/modules/base_sepolia/spot_markets.py
+++ b/dashboard/modules/base_sepolia/spot_markets.py
@@ -14,7 +14,7 @@ filters = {
 
 
 ## data
-@st.cache_data(ttl=1)
+@st.cache_data(ttl=600)
 def fetch_data(settings):
     # get filters
     start_date = filters["start_date"]
@@ -74,7 +74,6 @@ def fetch_data(settings):
     }
 
 
-@st.cache_data(ttl=1)
 def make_charts(data):
     return {
         "supply": chart_lines(

--- a/dashboard/modules/milestones/base_andromeda.py
+++ b/dashboard/modules/milestones/base_andromeda.py
@@ -6,7 +6,7 @@ from .charts import chart_volume, chart_collateral
 
 
 ## data
-@st.cache_data(ttl=1)
+@st.cache_data(ttl=600)
 def fetch_data():
     # set filters
     start_date = datetime.today().date() - timedelta(days=28)
@@ -61,7 +61,6 @@ def fetch_data():
     }
 
 
-@st.cache_data(ttl=1)
 def make_charts(data):
     return {
         "volume": chart_volume(data["stats"]),

--- a/dashboard/modules/op_mainnet/perp_integrators.py
+++ b/dashboard/modules/op_mainnet/perp_integrators.py
@@ -35,11 +35,11 @@ def make_daily_data(df):
         "kwentapysdk",
     ]
     df["tracking_code"] = df["trackingCode"].apply(
-        lambda x: x.capitalize()
-        if x.lower() in keepers
-        else "No tracking code"
-        if x == ""
-        else "Other"
+        lambda x: (
+            x.capitalize()
+            if x.lower() in keepers
+            else "No tracking code" if x == "" else "Other"
+        )
     )
     df["day"] = df["date"].dt.floor("D")
 
@@ -128,7 +128,6 @@ def filter_data(df, start_date, end_date, assets):
 
 
 ## charts
-@st.cache_data(ttl=600)
 def make_charts(df, df_daily):
     return {
         "fees": chart_bars(

--- a/dashboard/modules/op_mainnet/perp_markets.py
+++ b/dashboard/modules/op_mainnet/perp_markets.py
@@ -71,7 +71,6 @@ def filter_data(df, df_trade, df_funding, start_date, end_date):
 
 
 ## charts
-@st.cache_data(ttl=1)
 def make_charts(df, df_daily, df_trade, df_funding, asset):
     df = df[df["asset"] == asset]
     df_daily = df_daily[df_daily["asset"] == asset]

--- a/dashboard/modules/op_mainnet/perp_monitor.py
+++ b/dashboard/modules/op_mainnet/perp_monitor.py
@@ -7,7 +7,7 @@ from utils import chart_many_bars, export_data
 
 
 ## data
-@st.cache_data(ttl=600)
+@st.cache_data(ttl=60)
 def fetch_data():
     # initialize connection
     conn = sqlite3.connect("/app/data/perps.db")
@@ -92,7 +92,6 @@ def filter_data(df, df_trade, start_date, end_date, assets):
 
 
 ## charts
-@st.cache_data(ttl=600)
 def make_charts(df_hourly):
     return {
         "volume": chart_many_bars(

--- a/dashboard/modules/op_mainnet/perp_stats.py
+++ b/dashboard/modules/op_mainnet/perp_stats.py
@@ -123,7 +123,6 @@ def filter_data(df, df_trade, start_date, end_date, assets):
 
 
 ## charts
-@st.cache_data(ttl=600)
 def make_charts(df, df_daily, df_trade, df_oi):
     return {
         "pnl": chart_lines(


### PR DESCRIPTION
* Add a historical "all markets" skew dashboard
* Add a "current skew" for each market
* Update caching settings to 10 minutes across the app, but 60 seconds on "monitor" pages