### PR TITLE
Bug: Fix rewards

### DIFF
--- a/transformers/synthetix/models/marts/core/fct_pool_rewards_token_hourly.sql
+++ b/transformers/synthetix/models/marts/core/fct_pool_rewards_token_hourly.sql
@@ -34,37 +34,24 @@ rewards_distributed AS (
     FROM
         {{ ref('fct_pool_rewards') }}
 ),
-hourly_rewards AS (
+hourly_distributions AS (
     SELECT
         dim.ts,
         dim.pool_id,
         dim.collateral_type,
         r.distributor,
         r.market_symbol,
-        p.price,
-        -- get the hourly amount distributed
-        r.amount / (
-            r."duration" / 3600
-        ) AS hourly_amount,
-        -- get the amount of time distributed this hour
-        -- use the smaller of those two intervals
-        -- convert the interval to a number of hours
-        -- multiply the result by the hourly amount to get the amount distributed this hour
-        (
-            EXTRACT(
-                epoch
-                FROM
-                    LEAST(
-                        "duration" / 3600 * '1 hour' :: INTERVAL,
-                        dim.ts + '1 hour' :: INTERVAL - GREATEST(
-                            dim.ts,
-                            r.ts_start
-                        )
-                    )
-            ) / 3600
-        ) * r.amount / (
-            r."duration" / 3600
-        ) AS amount_distributed
+        r.amount,
+        r.ts_start,
+        r."duration",
+        ROW_NUMBER() over (
+            PARTITION BY dim.ts,
+            dim.pool_id,
+            dim.collateral_type,
+            r.distributor
+            ORDER BY
+                r.ts_start DESC
+        ) AS distributor_index
     FROM
         dim
         LEFT JOIN rewards_distributed r
@@ -76,10 +63,46 @@ hourly_rewards AS (
         )
         AND dim.ts + '1 hour' :: INTERVAL >= r.ts_start
         AND dim.ts < r.ts_start + r."duration" * '1 second' :: INTERVAL
+),
+hourly_rewards AS (
+    SELECT
+        d.ts,
+        d.pool_id,
+        d.collateral_type,
+        d.distributor,
+        d.market_symbol,
+        p.price,
+        -- get the hourly amount distributed
+        d.amount / (
+            d."duration" / 3600
+        ) AS hourly_amount,
+        -- get the amount of time distributed this hour
+        -- use the smaller of those two intervals
+        -- convert the interval to a number of hours
+        -- multiply the result by the hourly amount to get the amount distributed this hour
+        (
+            EXTRACT(
+                epoch
+                FROM
+                    LEAST(
+                        d."duration" / 3600 * '1 hour' :: INTERVAL,
+                        d.ts + '1 hour' :: INTERVAL - GREATEST(
+                            d.ts,
+                            d.ts_start
+                        )
+                    )
+            ) / 3600
+        ) * d.amount / (
+            d."duration" / 3600
+        ) AS amount_distributed
+    FROM
+        hourly_distributions AS d
         LEFT JOIN {{ ref('fct_prices_hourly') }}
         p
-        ON dim.ts = p.ts
-        AND r.market_symbol = p.market_symbol
+        ON d.ts = p.ts
+        AND d.market_symbol = p.market_symbol
+    WHERE
+        d.distributor_index = 1
 )
 SELECT
     *,


### PR DESCRIPTION
Fix a bug where rewards distributors are "overwritten" in the contract, but duplicated in the SQL queries. The result was duplicated rewards for old reward distributions that are no longer active.