### PR TITLE
Strict types for reward distributors

### DIFF
--- a/transformers/synthetix/models/marts/core/fct_pool_rewards.sql
+++ b/transformers/synthetix/models/marts/core/fct_pool_rewards.sql
@@ -11,18 +11,25 @@ WITH rewards_distributed AS (
         "duration"
     FROM
         {{ ref('core_rewards_distributed') }}
+),
+distributors AS (
+    SELECT
+        CAST(distributor_address AS TEXT) AS distributor_address,
+        CAST(token_symbol AS TEXT) AS token_symbol
+    FROM
+        {{ ref(target.name ~ '_reward_distributors') }}
 )
 SELECT
     rd.ts,
     rd.pool_id,
     rd.collateral_type,
     rd.distributor,
-    dist.token_symbol,
+    distributors.token_symbol,
     rd.amount,
     rd.ts_start,
     rd.duration
 FROM
     rewards_distributed rd
-    join {{ ref(target.name ~ "_reward_distributors")}} dist on rd.distributor = dist.distributor_address
+    join distributors on rd.distributor = distributors.distributor_address
 ORDER BY
     ts

--- a/transformers/synthetix/seeds/schema.yml
+++ b/transformers/synthetix/seeds/schema.yml
@@ -1,0 +1,129 @@
+version: 2
+
+seeds:
+  # reward distributors
+  - name: arbitrum_mainnet_reward_distributors
+    description: "Mapping of reward distributor addresses to their respective reward tokens"
+    columns:
+      - name: distributor_address
+        description: "Address of the reward distributor contract"
+        meta:
+          type: string
+        tests:
+          - not_null
+      - name: token_symbol
+        description: "Symbol for the token received as reward"
+        meta:
+          type: string
+        tests:
+          - not_null
+  - name: arbitrum_sepolia_reward_distributors
+    description: "Mapping of reward distributor addresses to their respective reward tokens"
+    columns:
+      - name: distributor_address
+        description: "Address of the reward distributor contract"
+        meta:
+          type: string
+        tests:
+          - not_null
+      - name: token_symbol
+        description: "Symbol for the token received as reward"
+        meta:
+          type: string
+        tests:
+          - not_null
+  - name: base_mainnet_reward_distributors
+    description: "Mapping of reward distributor addresses to their respective reward tokens"
+    columns:
+      - name: distributor_address
+        description: "Address of the reward distributor contract"
+        meta:
+          type: string
+        tests:
+          - not_null
+      - name: token_symbol
+        description: "Symbol for the token received as reward"
+        meta:
+          type: string
+        tests:
+          - not_null
+  - name: base_sepolia_reward_distributors
+    description: "Mapping of reward distributor addresses to their respective reward tokens"
+    columns:
+      - name: distributor_address
+        description: "Address of the reward distributor contract"
+        meta:
+          type: string
+        tests:
+          - not_null
+      - name: token_symbol
+        description: "Symbol for the token received as reward"
+        meta:
+          type: string
+        tests:
+          - not_null
+
+  # tokens
+  - name: arbitrum_mainnet_tokens
+    description: "Mapping of common token addresses to their respective token symbols"
+    columns:
+      - name: token_address
+        description: "Address of the token contract"
+        meta:
+          type: string
+        tests:
+          - not_null
+      - name: token_symbol
+        description: "Symbol for the token"
+        meta:
+          type: string
+        tests:
+          - not_null
+
+  - name: arbitrum_sepolia_tokens
+    description: "Mapping of common token addresses to their respective token symbols"
+    columns:
+      - name: token_address
+        description: "Address of the token contract"
+        meta:
+          type: string
+        tests:
+          - not_null
+      - name: token_symbol
+        description: "Symbol for the token"
+        meta:
+          type: string
+        tests:
+          - not_null
+
+  - name: base_mainnet_tokens
+    description: "Mapping of common token addresses to their respective token symbols"
+    columns:
+      - name: token_address
+        description: "Address of the token contract"
+        meta:
+          type: string
+        tests:
+          - not_null
+      - name: token_symbol
+        description: "Symbol for the token"
+        meta:
+          type: string
+        tests:
+          - not_null
+
+  - name: base_sepolia_tokens
+    description: "Mapping of common token addresses to their respective token symbols"
+    columns:
+      - name: token_address
+        description: "Address of the token contract"
+        meta:
+          type: string
+        tests:
+          - not_null
+      - name: token_symbol
+        description: "Symbol for the token"
+        meta:
+          type: string
+        tests:
+          - not_null


### PR DESCRIPTION
Adding more strict typing to reward distributor seed, since it is failing on testnets where there are no distributors.