### PR TITLE
Bug: Hourly Issuance

### DIFF
--- a/transformers/synthetix/models/marts/core/fct_core_apr.sql
+++ b/transformers/synthetix/models/marts/core/fct_core_apr.sql
@@ -23,10 +23,7 @@ WITH pnl_hourly AS (
                 ts
         ) AS cumulative_issuance,
         SUM(
-            hourly_pnl + COALESCE(
-                hourly_issuance,
-                0
-            )
+            hourly_pnl
         ) over (
             PARTITION BY pool_id,
             collateral_type

--- a/transformers/synthetix/models/marts/core/fct_pool_debt.sql
+++ b/transformers/synthetix/models/marts/core/fct_pool_debt.sql
@@ -1,5 +1,6 @@
 SELECT
     ts,
+    block_number,
     pool_id,
     collateral_type,
     debt

--- a/transformers/synthetix/models/marts/core/fct_pool_issuance.sql
+++ b/transformers/synthetix/models/marts/core/fct_pool_issuance.sql
@@ -1,6 +1,7 @@
 WITH burns AS (
     SELECT
         block_timestamp AS ts,
+        block_number,
         transaction_hash,
         pool_id,
         collateral_type,
@@ -14,6 +15,7 @@ WITH burns AS (
 mints AS (
     SELECT
         block_timestamp AS ts,
+        block_number,
         transaction_hash,
         pool_id,
         collateral_type,


### PR DESCRIPTION
Fixes a bug where the hourly issuance table sometimes includes changes that the debt table does not. This results in "spikes" in the pnl data in subsequent hours.

The fix is the limit the hourly issuance table to block before the latest debt value. This ensures issuance is always includes after debt is updated.