### PR TITLE
Temporary dependency fix for dbt docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,7 @@ jobs:
           python-version: 3.10.11
       - name: Install python dependencies
         run: |
-          cd transformers && pip install -r requirements.txt
+          cd transformers && pip install -I --force-reinstall setuptools==71.0.0 && pip install --no-build-isolation --no-cache-dir -r requirements.txt
       - name: Install dbt dependencies
         run: |
           cd transformers/synthetix && dbt deps


### PR DESCRIPTION
Problem: https://github.com/Synthetixio/data/actions/runs/10142703958/job/28042524316

Root cause is with `setuptools` breaking the dependency graph when trying to install `dbt-postgres`. Issue is new: https://stackoverflow.com/questions/78806100/no-module-named-setuptools-command-test/78806146#comment138941935_78806146

Temporary fix is to force install an older version of `setuptools` and isolate it: https://github.com/pypa/setuptools/issues/4519#issuecomment-2255358015