### PR TITLE
Pin `st-pages` version

### DIFF
--- a/dashboard/requirements.txt
+++ b/dashboard/requirements.txt
@@ -1,5 +1,5 @@
 streamlit
-st-pages
+st-pages==0.5.0
 sqlalchemy
 psycopg2-binary
 plotly


### PR DESCRIPTION
There were breaking changes in a new version of `st-pages`, so we should pin to the old version until it is updated