### PR TITLE
Transformers - Table materialization for parquet data

### DIFF
--- a/transformers/synthetix/models/raw/arbitrum/mainnet/core/core_vault_collateral_arbitrum_mainnet.sql
+++ b/transformers/synthetix/models/raw/arbitrum/mainnet/core/core_vault_collateral_arbitrum_mainnet.sql
@@ -1,3 +1,9 @@
+{{
+    config(
+        materialized='table'
+    )
+}}
+
 WITH base AS (
     SELECT
         block_number,

--- a/transformers/synthetix/models/raw/arbitrum/mainnet/core/core_vault_debt_arbitrum_mainnet.sql
+++ b/transformers/synthetix/models/raw/arbitrum/mainnet/core/core_vault_debt_arbitrum_mainnet.sql
@@ -1,3 +1,9 @@
+{{
+    config(
+        materialized='table'
+    )
+}}
+
 WITH base AS (
     SELECT
         block_number,

--- a/transformers/synthetix/models/raw/arbitrum/sepolia/core/core_vault_collateral_arbitrum_sepolia.sql
+++ b/transformers/synthetix/models/raw/arbitrum/sepolia/core/core_vault_collateral_arbitrum_sepolia.sql
@@ -1,3 +1,9 @@
+{{
+    config(
+        materialized='table'
+    )
+}}
+
 WITH base AS (
     SELECT
         block_number,

--- a/transformers/synthetix/models/raw/arbitrum/sepolia/core/core_vault_debt_arbitrum_sepolia.sql
+++ b/transformers/synthetix/models/raw/arbitrum/sepolia/core/core_vault_debt_arbitrum_sepolia.sql
@@ -1,3 +1,9 @@
+{{
+    config(
+        materialized='table'
+    )
+}}
+
 WITH base AS (
     SELECT
         block_number,

--- a/transformers/synthetix/models/raw/base/mainnet/core/core_vault_collateral_base_mainnet.sql
+++ b/transformers/synthetix/models/raw/base/mainnet/core/core_vault_collateral_base_mainnet.sql
@@ -1,3 +1,10 @@
+{{
+    config(
+        materialized='table'
+    )
+}}
+
+
 WITH base AS (
     SELECT
         block_number,

--- a/transformers/synthetix/models/raw/base/mainnet/core/core_vault_debt_base_mainnet.sql
+++ b/transformers/synthetix/models/raw/base/mainnet/core/core_vault_debt_base_mainnet.sql
@@ -1,3 +1,10 @@
+{{
+    config(
+        materialized='table'
+    )
+}}
+
+
 WITH base AS (
     SELECT
         block_number,

--- a/transformers/synthetix/models/raw/base/sepolia/core/core_vault_collateral_base_sepolia.sql
+++ b/transformers/synthetix/models/raw/base/sepolia/core/core_vault_collateral_base_sepolia.sql
@@ -1,3 +1,9 @@
+{{
+    config(
+        materialized='table'
+    )
+}}
+
 WITH base AS (
     SELECT
         block_number,

--- a/transformers/synthetix/models/raw/base/sepolia/core/core_vault_debt_base_sepolia.sql
+++ b/transformers/synthetix/models/raw/base/sepolia/core/core_vault_debt_base_sepolia.sql
@@ -1,3 +1,9 @@
+{{
+    config(
+        materialized='table'
+    )
+}}
+
 WITH base AS (
     SELECT
         block_number,


### PR DESCRIPTION
The vault debt and collateral data stored as parquet bottlenecks querying downstream. Materializing the base tables should speed up the models.