### PR TITLE
Fix gov tests

### DIFF
--- a/transformers/synthetix/models/raw/snax/testnet/schema.yml
+++ b/transformers/synthetix/models/raw/snax/testnet/schema.yml
@@ -14,11 +14,6 @@ models:
           - unique
   - name: gov_vote_recorded_snax_testnet
     description: Records of voting events
-    tests:
-      - dbt_utils.recency:
-          datepart: hour
-          field: block_timestamp
-          interval: 1
     columns:
       - name: id
         description: Unique identifier for the event
@@ -81,11 +76,6 @@ models:
           - not_null
   - name: gov_vote_withdrawn_snax_testnet
     description: Records of vote withdrawal events on the SNAX testnet blockchain
-    tests:
-      - dbt_utils.recency:
-          datepart: hour
-          field: block_timestamp
-          interval: 1
     columns:
       - name: id
         description: Unique identifier for the vote withdrawal event


### PR DESCRIPTION
Removes a failing recency tests from an event, since we don't expect it to be emitted frequently.