### PR TITLE
Increase Arbitrum indexer rate limit

### DIFF
--- a/indexers/arbitrum-mainnet/squidgen.yaml
+++ b/indexers/arbitrum-mainnet/squidgen.yaml
@@ -1,7 +1,7 @@
 archive: https://v2.archive.subsquid.io/network/arbitrum-one
 chain:
   url: https://arb1.arbitrum.io/rpc
-  rateLimit: 5
+  rateLimit: 15
 finalityConfirmation: 1
 target:
   type: postgres

--- a/indexers/arbitrum-sepolia/squidgen.yaml
+++ b/indexers/arbitrum-sepolia/squidgen.yaml
@@ -1,7 +1,7 @@
 archive: https://v2.archive.subsquid.io/network/arbitrum-sepolia
 chain:
   url: https://sepolia-rollup.arbitrum.io/rpc
-  rateLimit: 5
+  rateLimit: 15
 finalityConfirmation: 1
 target:
   type: postgres


### PR DESCRIPTION
I think the arbitrum rate limits can safely be increased using public RPCs. This increases from ~4 blocks/sec to 12 blocks/sec which should resolve Issue #74 