### PR TITLE
Bug: Fix chain id tests (again)

### DIFF
--- a/transformers/synthetix/models/raw/snax/mainnet/schema.yml
+++ b/transformers/synthetix/models/raw/snax/mainnet/schema.yml
@@ -96,7 +96,7 @@ models:
         tests:
           - not_null
           - accepted_values:
-              values: ["2192"]
+              values: ["2192", "10", "1", "8453", "42161"]
       - name: block_timestamp
         description: UTC timestamp of the block containing the vote withdrawal event
         data_type: timestamp with time zone
@@ -213,7 +213,7 @@ models:
         tests:
           - not_null
           - accepted_values:
-              values: ["2192"]
+              values: ["2192", "10", "1", "8453", "42161"]
       - name: block_timestamp
         description: UTC timestamp of the block containing the vote withdrawal event
         data_type: timestamp with time zone
@@ -330,7 +330,7 @@ models:
         tests:
           - not_null
           - accepted_values:
-              values: ["2192"]
+              values: ["2192", "10", "1", "8453", "42161"]
       - name: block_timestamp
         description: UTC timestamp of the block containing the vote withdrawal event
         data_type: timestamp with time zone

--- a/transformers/synthetix/models/raw/snax/testnet/schema.yml
+++ b/transformers/synthetix/models/raw/snax/testnet/schema.yml
@@ -95,8 +95,6 @@ models:
         data_type: string
         tests:
           - not_null
-          - accepted_values:
-              values: ["13001"]
       - name: block_timestamp
         description: UTC timestamp of the block containing the vote withdrawal event
         data_type: timestamp with time zone


### PR DESCRIPTION
After checking the data, realized the chain id here is actually the source chain, so it shows `10` for existing events. Updating this to include all mainnets and remove the test from testnets