### PR TITLE
Bug: Ethereum debt migration

### DIFF
--- a/transformers/synthetix/models/marts/eth/mainnet/core/fct_core_migration_hourly_eth_mainnet.sql
+++ b/transformers/synthetix/models/marts/eth/mainnet/core/fct_core_migration_hourly_eth_mainnet.sql
@@ -37,7 +37,7 @@ migration as (
     from
         {{ ref('fct_core_migration_eth_mainnet') }}
     group by
-        ts,
+        date_trunc('hour', ts),
         pool_id,
         collateral_type
 )


### PR DESCRIPTION
Fix a bug in the ethereum debt migration where a group by isn't truncated properly, resulting in incorrect and duplicated data

Example:
<img width="555" alt="image" src="https://github.com/user-attachments/assets/38aaba9f-5da7-4022-93a9-e3595a1e4410">
