### PR TITLE
Optimize extractors service

### DIFF
--- a/extractors/configs/arbitrum_mainnet.yaml
+++ b/extractors/configs/arbitrum_mainnet.yaml
@@ -4,6 +4,7 @@ blocks:
   min_block: "232500000"
   requests_per_second: 25
   block_increment: 4000
+  chunk_size: 80
 
 eth_calls:
   - contract_name: "CoreProxy"
@@ -19,6 +20,7 @@ eth_calls:
     min_block: "218M"
     requests_per_second: 25
     block_increment: 4000
+    chunk_size: 80
 
   - contract_name: "CoreProxy"
     package_name: "system"
@@ -33,3 +35,4 @@ eth_calls:
     min_block: "218M"
     requests_per_second: 25
     block_increment: 4000
+    chunk_size: 80

--- a/extractors/configs/arbitrum_sepolia.yaml
+++ b/extractors/configs/arbitrum_sepolia.yaml
@@ -4,6 +4,8 @@ blocks:
   min_block: "41M"
   requests_per_second: 25
   block_increment: 4000
+  chunk_size: 80
+
 
 eth_calls:
   - contract_name: "CoreProxy"
@@ -19,6 +21,7 @@ eth_calls:
     min_block: "41M"
     requests_per_second: 25
     block_increment: 4000
+    chunk_size: 80
 
   - contract_name: "CoreProxy"
     package_name: "system"
@@ -33,3 +36,4 @@ eth_calls:
     min_block: "41M"
     requests_per_second: 25
     block_increment: 4000
+    chunk_size: 80

--- a/extractors/configs/base_mainnet.yaml
+++ b/extractors/configs/base_mainnet.yaml
@@ -3,6 +3,8 @@ network_id: 8453
 blocks:
   min_block: "7.5M"
   requests_per_second: 25
+  block_increment: 500
+  chunk_size: 80
 
 eth_calls:
   - contract_name: "CoreProxy"
@@ -13,6 +15,8 @@ eth_calls:
       - [1, "0x729Ef31D86d31440ecBF49f27F7cD7c16c6616d2"]
     min_block: "7.5M"
     requests_per_second: 25
+    block_increment: 500
+    chunk_size: 80
 
   - contract_name: "CoreProxy"
     package_name: "system"
@@ -22,3 +26,5 @@ eth_calls:
       - [1, "0x729Ef31D86d31440ecBF49f27F7cD7c16c6616d2"]
     min_block: "7.5M"
     requests_per_second: 25
+    block_increment: 500
+    chunk_size: 80

--- a/extractors/configs/base_sepolia.yaml
+++ b/extractors/configs/base_sepolia.yaml
@@ -3,6 +3,8 @@ network_id: 84532
 blocks:
   min_block: "8M"
   requests_per_second: 25
+  block_increment: 500
+  chunk_size: 80
 
 eth_calls:
   - contract_name: "CoreProxy"
@@ -12,6 +14,8 @@ eth_calls:
       - [1, "0x8069c44244e72443722cfb22DcE5492cba239d39"]
     min_block: "8M"
     requests_per_second: 25
+    block_increment: 500
+    chunk_size: 80
 
   - contract_name: "CoreProxy"
     package_name: "system"
@@ -20,3 +24,5 @@ eth_calls:
       - [1, "0x8069c44244e72443722cfb22DcE5492cba239d39"]
     min_block: "8M"
     requests_per_second: 25
+    block_increment: 500
+    chunk_size: 80

--- a/extractors/configs/eth_mainnet.yaml
+++ b/extractors/configs/eth_mainnet.yaml
@@ -4,6 +4,7 @@ blocks:
   min_block: "20000000"
   requests_per_second: 25
   block_increment: 150
+  chunk_size: 50
 
 eth_calls:
   - contract_name: "CoreProxy"
@@ -14,6 +15,7 @@ eth_calls:
     min_block: "20000000"
     requests_per_second: 25
     block_increment: 150
+    chunk_size: 50
 
   - contract_name: "CoreProxy"
     package_name: "system"
@@ -23,3 +25,4 @@ eth_calls:
     min_block: "20000000"
     requests_per_second: 25
     block_increment: 150
+    chunk_size: 50

--- a/extractors/main.py
+++ b/extractors/main.py
@@ -37,14 +37,21 @@ if args.name:
             print(f"No configuration found with name {args.name}")
 else:
     # run everything
+    exceptions = []
     try:
         extract_blocks(network_id=network_id, **block_config)
     except Exception as e:
+        exceptions.append(e)
         print(f"Error extracting blocks: {e}")
 
     for eth_call_config in eth_call_configs:
         try:
             extract_data(network_id=network_id, **eth_call_config)
         except Exception as e:
+            exceptions.append(e)
             print(f"Error extracting eth_call {eth_call_config.get('name')}: {e}")
             continue
+
+    # if there are any exceptions, raise the first one
+    if len(exceptions) > 0:
+        raise Exception(exceptions[0])

--- a/extractors/requirements.txt
+++ b/extractors/requirements.txt
@@ -5,5 +5,5 @@ duckdb==0.10.2
 polars-lts-cpu==1.1.0
 pandas
 numpy
-synthetix==0.1.13
+synthetix==0.1.19
 web3==6.20.2

--- a/extractors/src/extract.py
+++ b/extractors/src/extract.py
@@ -29,6 +29,7 @@ def extract_data(
     min_block=0,
     requests_per_second=25,
     block_increment=500,
+    chunk_size=1000,
 ):
     if network_id not in CHAIN_CONFIGS:
         raise ValueError(f"Network id {network_id} not supported")
@@ -52,6 +53,7 @@ def extract_data(
         blocks=[f"{min_block}:latest:{block_increment}"],
         rpc=snx.provider_rpc,
         requests_per_second=requests_per_second,
+        chunk_size=chunk_size,
         output_dir=output_dir,
         hex=True,
         exclude_failed=True,
@@ -67,6 +69,7 @@ def extract_blocks(
     min_block=0,
     requests_per_second=25,
     block_increment=500,
+    chunk_size=1000,
 ):
     if network_id not in CHAIN_CONFIGS:
         raise ValueError(f"Network id {network_id} not supported")
@@ -83,6 +86,7 @@ def extract_blocks(
         blocks=[f"{min_block}:latest:{block_increment}"],
         rpc=snx.provider_rpc,
         requests_per_second=requests_per_second,
+        chunk_size=chunk_size,
         output_dir=output_dir,
         hex=True,
         exclude_failed=True,


### PR DESCRIPTION
**Optimizations**

- Optimize the `eth_calls` in the extractors service by adding a `chunk_size` parameter and setting it properly. These `chunk_size` values estimate just under 1 day looking backward based on average block times. This will ensure that `extractors` calls will generally fetch 1-2 days worth of data, which aligns with our daily schedule.
- - Additionally, this will reduce the total number of calls for the "latest chunk" and reduce extractor run times.

**Improvements**
- Add exception tracking when calling an entire config. This will ensure that errors are thrown when extractors calls fail, where they will currently fail silently.
- Update `synthetix` library to the latest version