### PR TITLE
Docker updates

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "2.4"
-
 services:
   db:
     image: ghcr.io/synthetixio/data/postgres:${VERSION}

--- a/scheduler/Dockerfile
+++ b/scheduler/Dockerfile
@@ -17,6 +17,7 @@ RUN pip install --no-cache-dir -r /transformers_requirements.txt
 
 ENV AIRFLOW__CORE__LOAD_EXAMPLES=False
 ENV AIRFLOW__WEBSERVER__RBAC=True
+ENV AIRFLOW__WEBSERVER__WARN_DEPLOYMENT_EXPOSURE=False
 
 COPY scheduler/entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
Two small updates:
- Remove docker compose version because of the warning
- Disable the airflow warning for a public deployment