### PR TITLE
Indexer - Optimize Data Import

### DIFF
--- a/indexers/utils/clickhouse_utils.py
+++ b/indexers/utils/clickhouse_utils.py
@@ -356,7 +356,6 @@ class ParquetImporter:
             dirs_to_import[i : i + batch_size]
             for i in range(0, len(dirs_to_import), batch_size)
         ]
-        total_insertions = 0
 
         time_start = time.time()
         for dir_batch in dirs_to_import_batched:

--- a/indexers/utils/clickhouse_utils.py
+++ b/indexers/utils/clickhouse_utils.py
@@ -327,6 +327,26 @@ class ParquetImporter:
         self.logger.info(f"Processed {data_insertions} insertions for {directory}")
         return data_insertions
 
+    def import_batch(self, batch: list[str]):
+        """
+        Import a batch of data directories
+        """
+        any_dir = batch[0]
+        dir_path = self.data_path / any_dir
+        event_list = []
+        for parquet_file in dir_path.glob("*.parquet"):
+            event_list.append(parquet_file.stem)
+
+        for event in event_list:
+            if event == "transaction":
+                continue
+            table_name = f"{self.protocol_name}_{event}"
+            clickhouse_file_path = (
+                self.clickhouse_internal_path / "*" / f"{event}.parquet"
+            )
+            self._insert_data_from_path(table_name, clickhouse_file_path, batch)
+            self.logger.info(f"Inserted {event} from batch")
+
     def import_data(self, batch_size: int = 100):
         """
         Import all new data in batches of size batch_size
@@ -340,13 +360,10 @@ class ParquetImporter:
 
         time_start = time.time()
         for dir_batch in dirs_to_import_batched:
-            for dir in dir_batch:
-                total_insertions += self.import_directory(dir)
+            self.import_batch(dir_batch)
         time_end = time.time()
         self.logger.info(f"Time taken: {time_end - time_start} seconds")
-        self.logger.info(f"Total insertions: {total_insertions}")
-        return total_insertions
-
+    
     def _insert_data_from_path(
         self,
         table_name: str,


### PR DESCRIPTION
Add a new `import_batch` function which takes a list of block ranges and performs a single insert query per event, matching for the block ranges. This will run much faster in comparison with performing a query for each event and for each block range individually.

To test:
1. Drop the raw database so that the indexer must first recreate the db and insert the missing data (in this case all of it)
2. Run the indexer `docker compose -f docker-compose.indexers.yml up indexer-base-mainnet-synthetix` (or another network-protocol combination)
