### PR TITLE
Update LT trades

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ import:
 	docker compose run transformer python scripts/import_parquet.py
 
 dbt: build
-	docker compose run transformer dbt run --target prod --profiles-dir profiles --profile synthetix --select +marts.base.mainnet.leveraged_tokens
+	docker compose run transformer dbt run --target prod --profiles-dir profiles --profile synthetix
 
 seed-prod: build
 	docker compose run transformer dbt seed --target prod --profiles-dir profiles --profile synthetix

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ import:
 	docker compose run transformer python scripts/import_parquet.py
 
 dbt: build
-	docker compose run transformer dbt run --target prod --profiles-dir profiles --profile synthetix
+	docker compose run transformer dbt run --target prod --profiles-dir profiles --profile synthetix --select +marts.base.mainnet.leveraged_tokens
 
 seed-prod: build
 	docker compose run transformer dbt seed --target prod --profiles-dir profiles --profile synthetix

--- a/transformers/synthetix/models/marts/base/mainnet/leveraged_tokens/lt_trades_base_mainnet.sql
+++ b/transformers/synthetix/models/marts/base/mainnet/leveraged_tokens/lt_trades_base_mainnet.sql
@@ -14,7 +14,14 @@ with trades as (
         a.leveraged_token_amount,
         a.base_asset_amount,
         abs(a.leveraged_token_amount) as nominal_volume,
-        abs(a.leveraged_token_amount) * a.leverage as notional_volume
+        abs(a.leveraged_token_amount) * a.leverage as notional_volume,
+        abs(a.base_asset_amount) / abs(a.leveraged_token_amount) as token_price,
+        sum(a.leveraged_token_amount)
+            over (partition by contract order by ts)
+        as total_supply,
+        sum(a.base_asset_amount)
+            over (partition by contract order by ts)
+        as vault_tvl
     from (
 
         select
@@ -51,23 +58,9 @@ with trades as (
             {{ convert_wei('base_asset_amount') }} * -1 as base_asset_amount
         from {{ ref('lt_redeemed_base_mainnet') }}
     ) as a
-),
-
-prices as (
-    select distinct
-        market_symbol as market,
-        block_number,
-        last(fill_price)
-            over (partition by market_symbol, block_number order by id)
-        as price
-    from {{ ref('fct_perp_trades_base_mainnet') }}
 )
 
 select
-    trades.*,
-    prices.price
+    *,
+    vault_tvl * leverage as vault_oi
 from trades
-left join prices
-    on
-        trades.market = prices.market
-        and trades.block_number = prices.block_number

--- a/transformers/synthetix/models/marts/base/mainnet/leveraged_tokens/lt_trades_base_mainnet.sql
+++ b/transformers/synthetix/models/marts/base/mainnet/leveraged_tokens/lt_trades_base_mainnet.sql
@@ -15,7 +15,7 @@ with trades as (
         a.base_asset_amount,
         abs(a.base_asset_amount) as nominal_volume,
         abs(a.base_asset_amount) * a.leverage as notional_volume,
-        abs(a.leveraged_token_amount) / abs(a.base_asset_amount) as token_price,
+        abs(a.base_asset_amount) / abs(a.leveraged_token_amount) as token_price,
         sum(a.leveraged_token_amount)
             over (partition by contract order by ts)
         as total_supply

--- a/transformers/synthetix/models/marts/base/mainnet/leveraged_tokens/lt_trades_base_mainnet.sql
+++ b/transformers/synthetix/models/marts/base/mainnet/leveraged_tokens/lt_trades_base_mainnet.sql
@@ -15,7 +15,7 @@ with trades as (
         a.base_asset_amount,
         abs(a.base_asset_amount) as nominal_volume,
         abs(a.base_asset_amount) * a.leverage as notional_volume,
-        abs(a.base_asset_amount) / abs(a.leveraged_token_amount) as token_price,
+        abs(a.leveraged_token_amount) / abs(a.base_asset_amount) as token_price,
         sum(a.leveraged_token_amount)
             over (partition by contract order by ts)
         as total_supply

--- a/transformers/synthetix/models/marts/base/mainnet/leveraged_tokens/lt_trades_base_mainnet.sql
+++ b/transformers/synthetix/models/marts/base/mainnet/leveraged_tokens/lt_trades_base_mainnet.sql
@@ -13,8 +13,8 @@ with trades as (
         upper(substring(a.token from '([^_]+)')) as market,
         a.leveraged_token_amount,
         a.base_asset_amount,
-        abs(a.leveraged_token_amount) as nominal_volume,
-        abs(a.leveraged_token_amount) * a.leverage as notional_volume,
+        abs(a.base_asset_amount) as nominal_volume,
+        abs(a.base_asset_amount) * a.leverage as notional_volume,
         abs(a.base_asset_amount) / abs(a.leveraged_token_amount) as token_price,
         sum(a.leveraged_token_amount)
             over (partition by contract order by ts)

--- a/transformers/synthetix/models/marts/base/mainnet/leveraged_tokens/lt_trades_base_mainnet.sql
+++ b/transformers/synthetix/models/marts/base/mainnet/leveraged_tokens/lt_trades_base_mainnet.sql
@@ -18,10 +18,7 @@ with trades as (
         abs(a.base_asset_amount) / abs(a.leveraged_token_amount) as token_price,
         sum(a.leveraged_token_amount)
             over (partition by contract order by ts)
-        as total_supply,
-        sum(a.base_asset_amount)
-            over (partition by contract order by ts)
-        as vault_tvl
+        as total_supply
     from (
 
         select
@@ -62,5 +59,6 @@ with trades as (
 
 select
     *,
-    vault_tvl * leverage as vault_oi
+    total_supply * token_price as vault_tvl,
+    total_supply * token_price * leverage as vault_oi
 from trades

--- a/transformers/synthetix/models/marts/optimism/mainnet/lt_leaderboard.sql
+++ b/transformers/synthetix/models/marts/optimism/mainnet/lt_leaderboard.sql
@@ -14,8 +14,8 @@ actions as (
             'week',
             block_timestamp + INTERVAL '6 day'
         ) - INTERVAL '6 day' as epoch_start,
-        COALESCE (z.account, r.account) as account,
-        {{ convert_wei('leveraged_token_amount') }}  * CAST(
+        COALESCE(z.account, r.account) as account,
+        {{ convert_wei('leveraged_token_amount') }} * CAST(
             REGEXP_REPLACE(
                 token,
                 '.*_(long|short)',
@@ -41,7 +41,7 @@ actions as (
             'week',
             block_timestamp + INTERVAL '6 day'
         ) - INTERVAL '6 day' as epoch_start,
-        COALESCE (z.account, m.account) as account,
+        COALESCE(z.account, m.account) as account,
         {{ convert_wei('leveraged_token_amount') }} * CAST(
             REGEXP_REPLACE(
                 token,

--- a/transformers/synthetix/models/marts/optimism/mainnet/lt_trades_optimism_mainnet.sql
+++ b/transformers/synthetix/models/marts/optimism/mainnet/lt_trades_optimism_mainnet.sql
@@ -1,5 +1,13 @@
-with trades as (
+with
+zap_accounts as (
+    select distinct
+        transaction_hash,
+        account
+    from
+        {{ ref('tlx_lt_zap_swaps_optimism_mainnet') }}
+),
 
+trades as (
     select
         a.id,
         a.block_number,
@@ -13,61 +21,59 @@ with trades as (
         upper(substring(a.token from '([^_]+)')) as market,
         a.leveraged_token_amount,
         a.base_asset_amount,
-        abs(a.leveraged_token_amount) as nominal_volume,
-        abs(a.leveraged_token_amount) * a.leverage as notional_volume
+        abs(a.base_asset_amount) as nominal_volume,
+        abs(a.base_asset_amount) * a.leverage as notional_volume,
+        abs(a.base_asset_amount) / abs(a.leveraged_token_amount) as token_price,
+        sum(a.leveraged_token_amount)
+            over (partition by contract order by ts)
+        as total_supply
     from (
-
         select
-            id,
-            block_number,
-            block_timestamp as ts,
-            transaction_hash,
-            contract,
-            event_name,
-            account,
-            token,
+            m.id,
+            m.block_number,
+            m.block_timestamp as ts,
+            m.transaction_hash,
+            m.contract,
+            m.event_name,
+            COALESCE(z.account, m.account) as account,
+            m.token,
             cast(
-                regexp_replace(token, '.*_(long|short)', '') as int
+                regexp_replace(m.token, '.*_(long|short)', '') as int
             ) as leverage,
-            {{ convert_wei('leveraged_token_amount') }}
+            -- Swapped columns for contract bug
+            {{ convert_wei('m.base_asset_amount') }}
             as leveraged_token_amount,
-            {{ convert_wei('base_asset_amount') }} as base_asset_amount
-        from {{ ref('tlx_lt_minted_optimism_mainnet') }}
+            {{ convert_wei('m.leveraged_token_amount') }} as base_asset_amount
+        from {{ ref('tlx_lt_minted_optimism_mainnet') }} as m
+        left join zap_accounts as z
+            on m.transaction_hash = z.transaction_hash
+        
         union all
+        
         select
-            id,
-            block_number,
-            block_timestamp as ts,
-            transaction_hash,
-            contract,
-            event_name,
-            account,
-            token,
+            r.id,
+            r.block_number,
+            r.block_timestamp as ts,
+            r.transaction_hash,
+            r.contract,
+            r.event_name,
+            COALESCE(z.account, r.account) as account,
+            r.token,
             cast(
-                regexp_replace(token, '.*_(long|short)', '') as int
+                regexp_replace(r.token, '.*_(long|short)', '') as int
             ) as leverage,
-            {{ convert_wei('leveraged_token_amount') }}
+            -- Swapped columns for contract bug
+            {{ convert_wei('r.base_asset_amount') }}
             * -1 as leveraged_token_amount,
-            {{ convert_wei('base_asset_amount') }} * -1 as base_asset_amount
-        from {{ ref('tlx_lt_redeemed_optimism_mainnet') }}
+            {{ convert_wei('r.leveraged_token_amount') }} * -1 as base_asset_amount
+        from {{ ref('tlx_lt_redeemed_optimism_mainnet') }} as r
+        left join zap_accounts as z
+            on r.transaction_hash = z.transaction_hash
     ) as a
-),
-
-prices as (
-    select distinct
-        market,
-        block_number,
-        last(price)
-            over (partition by market, block_number order by id)
-        as price
-    from {{ ref('fct_v2_trades_optimism_mainnet') }}
 )
 
 select
-    trades.*,
-    prices.price
+    *,
+    total_supply * token_price as vault_tvl,
+    total_supply * token_price * leverage as vault_oi
 from trades
-left join prices
-    on
-        trades.market = prices.market
-        and trades.block_number = prices.block_number


### PR DESCRIPTION
Updating the trades model to help satisfy both [USE-71](https://linear.app/ccsnx/issue/USE-71/leverage-mintredeem-history-data-collection) and [USE-73](https://linear.app/ccsnx/issue/USE-73/leveraged-token-stats-for-synthetix)

@ProblematicP would like a double-check on the logic here, no worries about the specific code:
- Notional volume = `baseAssetAmount * leverage`
- Nominal volume = `baseAssetAmount`
- Token price = `baseAssetAmount / leveragedTokenAmount`
  - This assumes that the USD amount amount divided by the number of tokens receives is the approximate USD price of the token
- Total supply = cumulative sum of `Minted.leveragedTokenAmount - Redeemed.leveragedTokenAmount`
- TVL = `total_supply * token_price`
- OI = `total_supply * token_price * leverage`