### PR TITLE
Add Reward Claimed Model

### DIFF
--- a/transformers/synthetix/models/marts/arbitrum/mainnet/core/fct_core_rewards_claimed_arbitrum_mainnet.sql
+++ b/transformers/synthetix/models/marts/arbitrum/mainnet/core/fct_core_rewards_claimed_arbitrum_mainnet.sql
@@ -50,4 +50,4 @@ inner join
         DATE_TRUNC('hour', rc.ts) = hourly_prices.ts
         and distributors.token_symbol = hourly_prices.market_symbol
 order by
-    ts
+    rc.ts

--- a/transformers/synthetix/models/marts/arbitrum/mainnet/core/fct_core_rewards_claimed_arbitrum_mainnet.sql
+++ b/transformers/synthetix/models/marts/arbitrum/mainnet/core/fct_core_rewards_claimed_arbitrum_mainnet.sql
@@ -1,0 +1,53 @@
+with rewards_claimed as (
+    select
+        block_timestamp as ts,
+        CAST(
+            pool_id as INTEGER
+        ) as pool_id,
+        account_id,
+        collateral_type,
+        distributor,
+        {{ convert_wei('amount') }} as amount
+    from
+        {{ ref('core_rewards_claimed_arbitrum_mainnet') }}
+),
+
+distributors as (
+    select
+        CAST(distributor_address as TEXT) as distributor_address,
+        CAST(token_symbol as TEXT) as token_symbol,
+        reward_type
+    from
+        {{ ref('arbitrum_mainnet_reward_distributors') }}
+),
+
+hourly_prices as (
+    select
+        ts,
+        market_symbol,
+        price
+    from
+        {{ ref('fct_prices_hourly_arbitrum_mainnet') }}
+)
+
+select
+    rc.ts,
+    rc.pool_id,
+    rc.collateral_type,
+    rc.account_id,
+    distributors.reward_type,
+    rc.distributor,
+    distributors.token_symbol,
+    rc.amount,
+    hourly_prices.price,
+    rc.amount * hourly_prices.price as amount_usd
+from
+    rewards_claimed as rc
+inner join distributors on rc.distributor = distributors.distributor_address
+inner join
+    hourly_prices
+    on
+        DATE_TRUNC('hour', rc.ts) = hourly_prices.ts
+        and distributors.token_symbol = hourly_prices.market_symbol
+order by
+    ts

--- a/transformers/synthetix/models/marts/arbitrum/mainnet/core/schema.yml
+++ b/transformers/synthetix/models/marts/arbitrum/mainnet/core/schema.yml
@@ -676,3 +676,79 @@ models:
         data_type: numeric
         tests:
           - not_null
+  - name: fct_core_reward_claims_arbitrum_mainnet
+    description: "Records of reward claims including token amounts and USD values"
+    columns:
+      - name: ts
+        description: "Block timestamp"
+        data_type: timestamp with time zone
+        tests:
+          - not_null
+
+      - name: pool_id
+        description: "ID of the pool"
+        data_type: numeric
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              min_value: 0
+              inclusive: true
+
+      - name: collateral_type
+        description: "Type of delegated collateral"
+        data_type: text
+        tests:
+          - not_null
+
+      - name: account_id
+        description: "ID of the account"
+        data_type: numeric
+        tests:
+          - not_null
+
+      - name: reward_type
+        description: "Type of reward (incentive or liquidation)"
+        data_type: text
+        tests:
+          - not_null
+          - accepted_values:
+              values: ["liquidation", "incentive"]
+
+      - name: distributor
+        description: "Address of the reward distributor"
+        data_type: text
+        tests:
+          - not_null
+
+      - name: token_symbol
+        description: "Symbol of the reward token"
+        data_type: text
+        tests:
+          - not_null
+
+      - name: amount
+        description: "Amount of reward tokens"
+        data_type: numeric
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              min_value: 0
+              inclusive: true
+
+      - name: price
+        description: "Price of the reward token in USD"
+        data_type: numeric
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              min_value: 0
+              inclusive: true
+
+      - name: amount_usd
+        description: "USD value of the reward amount"
+        data_type: numeric
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              min_value: 0
+              inclusive: true

--- a/transformers/synthetix/models/marts/base/mainnet/core/fct_core_rewards_claimed_base_mainnet.sql
+++ b/transformers/synthetix/models/marts/base/mainnet/core/fct_core_rewards_claimed_base_mainnet.sql
@@ -50,4 +50,4 @@ inner join
         DATE_TRUNC('hour', rc.ts) = hourly_prices.ts
         and distributors.token_symbol = hourly_prices.market_symbol
 order by
-    ts
+    rc.ts

--- a/transformers/synthetix/models/marts/base/mainnet/core/fct_core_rewards_claimed_base_mainnet.sql
+++ b/transformers/synthetix/models/marts/base/mainnet/core/fct_core_rewards_claimed_base_mainnet.sql
@@ -1,0 +1,53 @@
+with rewards_claimed as (
+    select
+        block_timestamp as ts,
+        CAST(
+            pool_id as INTEGER
+        ) as pool_id,
+        account_id,
+        collateral_type,
+        distributor,
+        {{ convert_wei('amount') }} as amount
+    from
+        {{ ref('core_rewards_claimed_base_mainnet') }}
+),
+
+distributors as (
+    select
+        CAST(distributor_address as TEXT) as distributor_address,
+        CAST(token_symbol as TEXT) as token_symbol,
+        reward_type
+    from
+        {{ ref('base_mainnet_reward_distributors') }}
+),
+
+hourly_prices as (
+    select
+        ts,
+        market_symbol,
+        price
+    from
+        {{ ref('fct_prices_hourly_base_mainnet') }}
+)
+
+select
+    rc.ts,
+    rc.pool_id,
+    rc.collateral_type,
+    rc.account_id,
+    distributors.reward_type,
+    rc.distributor,
+    distributors.token_symbol,
+    rc.amount,
+    hourly_prices.price,
+    rc.amount * hourly_prices.price as amount_usd
+from
+    rewards_claimed as rc
+inner join distributors on rc.distributor = distributors.distributor_address
+inner join
+    hourly_prices
+    on
+        DATE_TRUNC('hour', rc.ts) = hourly_prices.ts
+        and distributors.token_symbol = hourly_prices.market_symbol
+order by
+    ts

--- a/transformers/synthetix/models/marts/base/mainnet/core/schema.yml
+++ b/transformers/synthetix/models/marts/base/mainnet/core/schema.yml
@@ -753,3 +753,80 @@ models:
         data_type: numeric
         tests:
           - not_null
+
+  - name: fct_core_reward_claims_base_mainnet
+    description: "Records of reward claims including token amounts and USD values"
+    columns:
+      - name: ts
+        description: "Block timestamp"
+        data_type: timestamp with time zone
+        tests:
+          - not_null
+
+      - name: pool_id
+        description: "ID of the pool"
+        data_type: numeric
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              min_value: 0
+              inclusive: true
+
+      - name: collateral_type
+        description: "Type of delegated collateral"
+        data_type: text
+        tests:
+          - not_null
+
+      - name: account_id
+        description: "ID of the account"
+        data_type: numeric
+        tests:
+          - not_null
+
+      - name: reward_type
+        description: "Type of reward (incentive or liquidation)"
+        data_type: text
+        tests:
+          - not_null
+          - accepted_values:
+              values: ["liquidation", "incentive"]
+
+      - name: distributor
+        description: "Address of the reward distributor"
+        data_type: text
+        tests:
+          - not_null
+
+      - name: token_symbol
+        description: "Symbol of the reward token"
+        data_type: text
+        tests:
+          - not_null
+
+      - name: amount
+        description: "Amount of reward tokens"
+        data_type: numeric
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              min_value: 0
+              inclusive: true
+
+      - name: price
+        description: "Price of the reward token in USD"
+        data_type: numeric
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              min_value: 0
+              inclusive: true
+
+      - name: amount_usd
+        description: "USD value of the reward amount"
+        data_type: numeric
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              min_value: 0
+              inclusive: true

--- a/transformers/synthetix/models/marts/eth/mainnet/core/fct_core_rewards_claimed_eth_mainnet.sql
+++ b/transformers/synthetix/models/marts/eth/mainnet/core/fct_core_rewards_claimed_eth_mainnet.sql
@@ -50,4 +50,4 @@ inner join
         DATE_TRUNC('hour', rc.ts) = hourly_prices.ts
         and distributors.token_symbol = hourly_prices.market_symbol
 order by
-    ts
+    rc.ts

--- a/transformers/synthetix/models/marts/eth/mainnet/core/fct_core_rewards_claimed_eth_mainnet.sql
+++ b/transformers/synthetix/models/marts/eth/mainnet/core/fct_core_rewards_claimed_eth_mainnet.sql
@@ -1,0 +1,53 @@
+with rewards_claimed as (
+    select
+        block_timestamp as ts,
+        CAST(
+            pool_id as INTEGER
+        ) as pool_id,
+        account_id,
+        collateral_type,
+        distributor,
+        {{ convert_wei('amount') }} as amount
+    from
+        {{ ref('core_rewards_claimed_eth_mainnet') }}
+),
+
+distributors as (
+    select
+        CAST(distributor_address as TEXT) as distributor_address,
+        CAST(token_symbol as TEXT) as token_symbol,
+        reward_type
+    from
+        {{ ref('eth_mainnet_reward_distributors') }}
+),
+
+hourly_prices as (
+    select
+        ts,
+        market_symbol,
+        price
+    from
+        {{ ref('fct_prices_hourly_eth_mainnet') }}
+)
+
+select
+    rc.ts,
+    rc.pool_id,
+    rc.collateral_type,
+    rc.account_id,
+    distributors.reward_type,
+    rc.distributor,
+    distributors.token_symbol,
+    rc.amount,
+    hourly_prices.price,
+    rc.amount * hourly_prices.price as amount_usd
+from
+    rewards_claimed as rc
+inner join distributors on rc.distributor = distributors.distributor_address
+inner join
+    hourly_prices
+    on
+        DATE_TRUNC('hour', rc.ts) = hourly_prices.ts
+        and distributors.token_symbol = hourly_prices.market_symbol
+order by
+    ts


### PR DESCRIPTION
Adds a `fct_core_rewards_claimed` model for Base, Ethereum, and Arbitrum. This new model includes all rewards claimed per account, with a USD value applied to each one at the hourly price.