### PR TITLE
APR Model update

### DIFF
--- a/transformers/synthetix/models/marts/arbitrum/mainnet/core/fct_core_apr_arbitrum_mainnet.sql
+++ b/transformers/synthetix/models/marts/arbitrum/mainnet/core/fct_core_apr_arbitrum_mainnet.sql
@@ -17,6 +17,8 @@ with pnl_hourly as (
         hourly_pnl_pct,
         hourly_rewards_pct,
         hourly_total_pct,
+        hourly_rewards_pct as hourly_incentive_rewards_pct,
+        hourly_pnl_pct as hourly_performance_pct,
         sum(coalesce(hourly_issuance, 0)) over (
             partition by pool_id, collateral_type
             order by ts
@@ -81,7 +83,37 @@ avg_returns as (
             partition by pool_id, collateral_type
             order by ts
             range between interval '28 DAYS' preceding and current row
-        ) as avg_28d_total_pct
+        ) as avg_28d_total_pct,
+        avg(hourly_incentive_rewards_pct) over (
+            partition by pool_id, collateral_type
+            order by ts
+            range between interval '24 HOURS' preceding and current row
+        ) as avg_24h_incentive_rewards_pct,
+        avg(hourly_incentive_rewards_pct) over (
+            partition by pool_id, collateral_type
+            order by ts
+            range between interval '7 DAYS' preceding and current row
+        ) as avg_7d_incentive_rewards_pct,
+        avg(hourly_incentive_rewards_pct) over (
+            partition by pool_id, collateral_type
+            order by ts
+            range between interval '28 DAYS' preceding and current row
+        ) as avg_28d_incentive_rewards_pct,
+        avg(hourly_performance_pct) over (
+            partition by pool_id, collateral_type
+            order by ts
+            range between interval '24 HOURS' preceding and current row
+        ) as avg_24h_performance_pct,
+        avg(hourly_performance_pct) over (
+            partition by pool_id, collateral_type
+            order by ts
+            range between interval '7 DAYS' preceding and current row
+        ) as avg_7d_performance_pct,
+        avg(hourly_performance_pct) over (
+            partition by pool_id, collateral_type
+            order by ts
+            range between interval '28 DAYS' preceding and current row
+        ) as avg_28d_performance_pct
     from pnl_hourly
 ),
 
@@ -112,6 +144,20 @@ apr_calculations as (
         avg_returns.avg_24h_rewards_pct * 24 * 365 as apr_24h_rewards,
         avg_returns.avg_7d_rewards_pct * 24 * 365 as apr_7d_rewards,
         avg_returns.avg_28d_rewards_pct * 24 * 365 as apr_28d_rewards,
+        -- incentive rewards pnls
+        avg_returns.avg_24h_incentive_rewards_pct
+        * 24
+        * 365 as apr_24h_incentive_rewards,
+        avg_returns.avg_7d_incentive_rewards_pct
+        * 24
+        * 365 as apr_7d_incentive_rewards,
+        avg_returns.avg_28d_incentive_rewards_pct
+        * 24
+        * 365 as apr_28d_incentive_rewards,
+        -- performance pnls
+        avg_returns.avg_24h_performance_pct * 24 * 365 as apr_24h_performance,
+        avg_returns.avg_7d_performance_pct * 24 * 365 as apr_7d_performance,
+        avg_returns.avg_28d_performance_pct * 24 * 365 as apr_28d_performance,
         -- underlying yields
         coalesce(yr.apr_24h_underlying, 0) as apr_24h_underlying,
         coalesce(yr.apr_7d_underlying, 0) as apr_7d_underlying,
@@ -141,6 +187,22 @@ apy_calculations as (
         (power(1 + apr_24h_rewards / 8760, 8760) - 1) as apy_24h_rewards,
         (power(1 + apr_7d_rewards / 8760, 8760) - 1) as apy_7d_rewards,
         (power(1 + apr_28d_rewards / 8760, 8760) - 1) as apy_28d_rewards,
+        (
+            power(1 + apr_24h_incentive_rewards / 8760, 8760) - 1
+        ) as apy_24h_incentive_rewards,
+        (
+            power(1 + apr_7d_incentive_rewards / 8760, 8760) - 1
+        ) as apy_7d_incentive_rewards,
+        (
+            power(1 + apr_28d_incentive_rewards / 8760, 8760) - 1
+        ) as apy_28d_incentive_rewards,
+        (
+            power(1 + apr_24h_performance / 8760, 8760) - 1
+        ) as apy_24h_performance,
+        (power(1 + apr_7d_performance / 8760, 8760) - 1) as apy_7d_performance,
+        (
+            power(1 + apr_28d_performance / 8760, 8760) - 1
+        ) as apy_28d_performance,
         (power(1 + apr_24h_underlying / 8760, 8760) - 1) as apy_24h_underlying,
         (power(1 + apr_7d_underlying / 8760, 8760) - 1) as apy_7d_underlying,
         (power(1 + apr_28d_underlying / 8760, 8760) - 1) as apy_28d_underlying
@@ -179,6 +241,18 @@ select
     apy_7d_rewards,
     apr_28d_rewards,
     apy_28d_rewards,
+    apr_24h_incentive_rewards,
+    apy_24h_incentive_rewards,
+    apr_7d_incentive_rewards,
+    apy_7d_incentive_rewards,
+    apr_28d_incentive_rewards,
+    apy_28d_incentive_rewards,
+    apr_24h_performance,
+    apy_24h_performance,
+    apr_7d_performance,
+    apy_7d_performance,
+    apr_28d_performance,
+    apy_28d_performance,
     apr_24h_underlying,
     apy_24h_underlying,
     apr_7d_underlying,

--- a/transformers/synthetix/models/marts/arbitrum/mainnet/core/schema.yml
+++ b/transformers/synthetix/models/marts/arbitrum/mainnet/core/schema.yml
@@ -243,6 +243,30 @@ models:
         data_type: numeric
       - name: apy_28d_rewards
         data_type: numeric
+      - name: apr_24h_incentive_rewards
+        data_type: numeric
+      - name: apy_24h_incentive_rewards
+        data_type: numeric
+      - name: apr_7d_incentive_rewards
+        data_type: numeric
+      - name: apy_7d_incentive_rewards
+        data_type: numeric
+      - name: apr_28d_incentive_rewards
+        data_type: numeric
+      - name: apy_28d_incentive_rewards
+        data_type: numeric
+      - name: apr_24h_performance
+        data_type: numeric
+      - name: apy_24h_performance
+        data_type: numeric
+      - name: apr_7d_performance
+        data_type: numeric
+      - name: apy_7d_performance
+        data_type: numeric
+      - name: apr_28d_performance
+        data_type: numeric
+      - name: apy_28d_performance
+        data_type: numeric
       - name: apr_24h_underlying
         data_type: numeric
       - name: apy_24h_underlying

--- a/transformers/synthetix/models/marts/base/mainnet/core/fct_pool_pnl_hourly_base_mainnet.sql
+++ b/transformers/synthetix/models/marts/base/mainnet/core/fct_pool_pnl_hourly_base_mainnet.sql
@@ -250,7 +250,29 @@ hourly_returns as (
                     0
                 )
             ) / pnl.collateral_value
-        end as hourly_total_pct
+        end as hourly_total_pct,
+        case
+            when pnl.collateral_value = 0 then 0
+            else (coalesce(
+                rewards.rewards_usd,
+                0
+            ) - coalesce(
+                rewards.liquidation_rewards_usd,
+                0
+            )) / pnl.collateral_value
+        end as hourly_incentive_rewards_pct,
+        case
+            when pnl.collateral_value = 0 then 0
+            else (
+                coalesce(
+                    rewards.liquidation_rewards_usd,
+                    0
+                ) + pnl.hourly_pnl + coalesce(
+                    iss.hourly_issuance,
+                    0
+                )
+            ) / pnl.collateral_value
+        end as hourly_performance_pct
     from
         hourly_pnl as pnl
     left join hourly_rewards as rewards
@@ -285,6 +307,8 @@ select
     liquidation_rewards_usd,
     hourly_pnl_pct,
     hourly_rewards_pct,
-    hourly_total_pct
+    hourly_total_pct,
+    hourly_incentive_rewards_pct,
+    hourly_performance_pct
 from
     hourly_returns

--- a/transformers/synthetix/models/marts/base/mainnet/core/schema.yml
+++ b/transformers/synthetix/models/marts/base/mainnet/core/schema.yml
@@ -637,6 +637,22 @@ models:
         data_type: numeric
         tests:
           - not_null
+      - name: hourly_incentive_rewards_pct
+        description: "Hourly incentive rewards (%)"
+        data_type: numeric
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              min_value: 0
+              inclusive: true
+      - name: hourly_performance_pct
+        description: "Hourly performance (%)"
+        data_type: numeric
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              min_value: 0
+              inclusive: true
   - name: fct_pool_rewards_pool_hourly_base_mainnet
     columns:
       - name: ts

--- a/transformers/synthetix/models/marts/base/mainnet/core/schema.yml
+++ b/transformers/synthetix/models/marts/base/mainnet/core/schema.yml
@@ -305,6 +305,30 @@ models:
         data_type: numeric
       - name: apy_28d_rewards
         data_type: numeric
+      - name: apr_24h_incentive_rewards
+        data_type: numeric
+      - name: apy_24h_incentive_rewards
+        data_type: numeric
+      - name: apr_7d_incentive_rewards
+        data_type: numeric
+      - name: apy_7d_incentive_rewards
+        data_type: numeric
+      - name: apr_28d_incentive_rewards
+        data_type: numeric
+      - name: apy_28d_incentive_rewards
+        data_type: numeric
+      - name: apr_24h_performance
+        data_type: numeric
+      - name: apy_24h_performance
+        data_type: numeric
+      - name: apr_7d_performance
+        data_type: numeric
+      - name: apy_7d_performance
+        data_type: numeric
+      - name: apr_28d_performance
+        data_type: numeric
+      - name: apy_28d_performance
+        data_type: numeric
       - name: apr_24h_underlying
         data_type: numeric
       - name: apy_24h_underlying

--- a/transformers/synthetix/models/marts/eth/mainnet/core/fct_core_apr_eth_mainnet.sql
+++ b/transformers/synthetix/models/marts/eth/mainnet/core/fct_core_apr_eth_mainnet.sql
@@ -18,6 +18,8 @@ with pnl_hourly as (
         hourly_pnl_pct,
         hourly_rewards_pct,
         hourly_total_pct,
+        hourly_rewards_pct as hourly_incentive_rewards_pct,
+        hourly_pnl_pct as hourly_performance_pct,
         sum(coalesce(hourly_issuance, 0)) over (
             partition by pool_id, collateral_type
             order by ts
@@ -82,7 +84,37 @@ avg_returns as (
             partition by pool_id, collateral_type
             order by ts
             range between interval '28 DAYS' preceding and current row
-        ) as avg_28d_total_pct
+        ) as avg_28d_total_pct,
+        avg(hourly_incentive_rewards_pct) over (
+            partition by pool_id, collateral_type
+            order by ts
+            range between interval '24 HOURS' preceding and current row
+        ) as avg_24h_incentive_rewards_pct,
+        avg(hourly_incentive_rewards_pct) over (
+            partition by pool_id, collateral_type
+            order by ts
+            range between interval '7 DAYS' preceding and current row
+        ) as avg_7d_incentive_rewards_pct,
+        avg(hourly_incentive_rewards_pct) over (
+            partition by pool_id, collateral_type
+            order by ts
+            range between interval '28 DAYS' preceding and current row
+        ) as avg_28d_incentive_rewards_pct,
+        avg(hourly_performance_pct) over (
+            partition by pool_id, collateral_type
+            order by ts
+            range between interval '24 HOURS' preceding and current row
+        ) as avg_24h_performance_pct,
+        avg(hourly_performance_pct) over (
+            partition by pool_id, collateral_type
+            order by ts
+            range between interval '7 DAYS' preceding and current row
+        ) as avg_7d_performance_pct,
+        avg(hourly_performance_pct) over (
+            partition by pool_id, collateral_type
+            order by ts
+            range between interval '28 DAYS' preceding and current row
+        ) as avg_28d_performance_pct
     from pnl_hourly
 ),
 
@@ -114,6 +146,20 @@ apr_calculations as (
         avg_returns.avg_24h_rewards_pct * 24 * 365 as apr_24h_rewards,
         avg_returns.avg_7d_rewards_pct * 24 * 365 as apr_7d_rewards,
         avg_returns.avg_28d_rewards_pct * 24 * 365 as apr_28d_rewards,
+        -- incentive rewards pnls
+        avg_returns.avg_24h_incentive_rewards_pct
+        * 24
+        * 365 as apr_24h_incentive_rewards,
+        avg_returns.avg_7d_incentive_rewards_pct
+        * 24
+        * 365 as apr_7d_incentive_rewards,
+        avg_returns.avg_28d_incentive_rewards_pct
+        * 24
+        * 365 as apr_28d_incentive_rewards,
+        -- performance pnls
+        avg_returns.avg_24h_performance_pct * 24 * 365 as apr_24h_performance,
+        avg_returns.avg_7d_performance_pct * 24 * 365 as apr_7d_performance,
+        avg_returns.avg_28d_performance_pct * 24 * 365 as apr_28d_performance,
         -- underlying yields
         coalesce(yr.apr_24h_underlying, 0) as apr_24h_underlying,
         coalesce(yr.apr_7d_underlying, 0) as apr_7d_underlying,
@@ -143,6 +189,22 @@ apy_calculations as (
         (power(1 + apr_24h_rewards / 8760, 8760) - 1) as apy_24h_rewards,
         (power(1 + apr_7d_rewards / 8760, 8760) - 1) as apy_7d_rewards,
         (power(1 + apr_28d_rewards / 8760, 8760) - 1) as apy_28d_rewards,
+        (
+            power(1 + apr_24h_incentive_rewards / 8760, 8760) - 1
+        ) as apy_24h_incentive_rewards,
+        (
+            power(1 + apr_7d_incentive_rewards / 8760, 8760) - 1
+        ) as apy_7d_incentive_rewards,
+        (
+            power(1 + apr_28d_incentive_rewards / 8760, 8760) - 1
+        ) as apy_28d_incentive_rewards,
+        (
+            power(1 + apr_24h_performance / 8760, 8760) - 1
+        ) as apy_24h_performance,
+        (power(1 + apr_7d_performance / 8760, 8760) - 1) as apy_7d_performance,
+        (
+            power(1 + apr_28d_performance / 8760, 8760) - 1
+        ) as apy_28d_performance,
         (power(1 + apr_24h_underlying / 8760, 8760) - 1) as apy_24h_underlying,
         (power(1 + apr_7d_underlying / 8760, 8760) - 1) as apy_7d_underlying,
         (power(1 + apr_28d_underlying / 8760, 8760) - 1) as apy_28d_underlying
@@ -182,6 +244,18 @@ select
     apy_7d_rewards,
     apr_28d_rewards,
     apy_28d_rewards,
+    apr_24h_incentive_rewards,
+    apy_24h_incentive_rewards,
+    apr_7d_incentive_rewards,
+    apy_7d_incentive_rewards,
+    apr_28d_incentive_rewards,
+    apy_28d_incentive_rewards,
+    apr_24h_performance,
+    apy_24h_performance,
+    apr_7d_performance,
+    apy_7d_performance,
+    apr_28d_performance,
+    apy_28d_performance,
     apr_24h_underlying,
     apy_24h_underlying,
     apr_7d_underlying,

--- a/transformers/synthetix/models/marts/eth/mainnet/core/schema.yml
+++ b/transformers/synthetix/models/marts/eth/mainnet/core/schema.yml
@@ -248,6 +248,30 @@ models:
         data_type: numeric
       - name: apy_28d_rewards
         data_type: numeric
+      - name: apr_24h_incentive_rewards
+        data_type: numeric
+      - name: apy_24h_incentive_rewards
+        data_type: numeric
+      - name: apr_7d_incentive_rewards
+        data_type: numeric
+      - name: apy_7d_incentive_rewards
+        data_type: numeric
+      - name: apr_28d_incentive_rewards
+        data_type: numeric
+      - name: apy_28d_incentive_rewards
+        data_type: numeric
+      - name: apr_24h_performance
+        data_type: numeric
+      - name: apy_24h_performance
+        data_type: numeric
+      - name: apr_7d_performance
+        data_type: numeric
+      - name: apy_7d_performance
+        data_type: numeric
+      - name: apr_28d_performance
+        data_type: numeric
+      - name: apy_28d_performance
+        data_type: numeric
       - name: apr_24h_underlying
         data_type: numeric
       - name: apy_24h_underlying
@@ -788,3 +812,79 @@ models:
         data_type: numeric
         tests:
           - not_null
+  - name: fct_core_reward_claims_eth_mainnet
+    description: "Records of reward claims including token amounts and USD values"
+    columns:
+      - name: ts
+        description: "Block timestamp"
+        data_type: timestamp with time zone
+        tests:
+          - not_null
+
+      - name: pool_id
+        description: "ID of the pool"
+        data_type: numeric
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              min_value: 0
+              inclusive: true
+
+      - name: collateral_type
+        description: "Type of delegated collateral"
+        data_type: text
+        tests:
+          - not_null
+
+      - name: account_id
+        description: "ID of the account"
+        data_type: numeric
+        tests:
+          - not_null
+
+      - name: reward_type
+        description: "Type of reward (incentive or liquidation)"
+        data_type: text
+        tests:
+          - not_null
+          - accepted_values:
+              values: ["liquidation", "incentive"]
+
+      - name: distributor
+        description: "Address of the reward distributor"
+        data_type: text
+        tests:
+          - not_null
+
+      - name: token_symbol
+        description: "Symbol of the reward token"
+        data_type: text
+        tests:
+          - not_null
+
+      - name: amount
+        description: "Amount of reward tokens"
+        data_type: numeric
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              min_value: 0
+              inclusive: true
+
+      - name: price
+        description: "Price of the reward token in USD"
+        data_type: numeric
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              min_value: 0
+              inclusive: true
+
+      - name: amount_usd
+        description: "USD value of the reward amount"
+        data_type: numeric
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              min_value: 0
+              inclusive: true


### PR DESCRIPTION
Adds two new values for APRs: `incentive_rewards` and `performance`
- For ETH and Arbitrum, these will match exactly the `pnl` and `reward` versions currently used
- For Base, incentives are removed from the `total` APR to create the `performance` APR
- For Base, incentives are isolated to calculate a reward APR that doesn't include liquidated collateral

The new fields are:
- `apr_24h_incentive_rewards`
- `apy_24h_incentive_rewards`
- `apr_7d_incentive_rewards`
- `apy_7d_incentive_rewards`
- `apr_28d_incentive_rewards`
- `apy_28d_incentive_rewards`
- `apr_24h_performance`
- `apy_24h_performance`
- `apr_7d_performance`
- `apy_7d_performance`
- `apr_28d_performance`
- `apy_28d_performance`