### PR TITLE
Transformers - Update schemas

### DIFF
--- a/transformers/synthetix/models/marts/arbitrum/mainnet/core/schema.yml
+++ b/transformers/synthetix/models/marts/arbitrum/mainnet/core/schema.yml
@@ -621,62 +621,7 @@ models:
           - dbt_utils.accepted_range:
               min_value: 0
               inclusive: true
-  - name: fct_core_yield_metrics_arbitrum_mainnet
-    description: "Hourly yield metrics including exchange rates and trailing yield percentages"
-    columns:
-      - name: ts
-        description: "Block timestamp"
-        data_type: timestamp with time zone
-        tests:
-          - not_null
-
-      - name: pool_id
-        description: "ID of the pool"
-        data_type: numeric
-        tests:
-          - not_null
-          - dbt_utils.accepted_range:
-              min_value: 0
-              inclusive: true
-
-      - name: collateral_type
-        description: "Type of delegated collateral as an address"
-        data_type: text
-        tests:
-          - not_null
-
-      - name: exchange_rate
-        description: "Exchange rate between token and yield token (ie ETH and wstETH)"
-        data_type: numeric
-        tests:
-          - not_null
-          - dbt_utils.accepted_range:
-              min_value: 0
-
-      - name: hourly_exchange_rate_pnl
-        description: "Hourly change in exchange rate"
-        data_type: numeric
-        tests:
-          - not_null
-
-      - name: apr_24h_underlying
-        description: "Annualized yield percentage based on 24-hour average"
-        data_type: numeric
-        tests:
-          - not_null
-
-      - name: apr_7d_underlying
-        description: "Annualized yield percentage based on 7-day average"
-        data_type: numeric
-        tests:
-          - not_null
-
-      - name: apr_28d_underlying
-        description: "Annualized yield percentage based on 28-day average"
-        data_type: numeric
-        tests:
-          - not_null
-  - name: fct_core_reward_claims_arbitrum_mainnet
+  - name: fct_core_rewards_claimed_arbitrum_mainnet
     description: "Records of reward claims including token amounts and USD values"
     columns:
       - name: ts
@@ -684,7 +629,6 @@ models:
         data_type: timestamp with time zone
         tests:
           - not_null
-
       - name: pool_id
         description: "ID of the pool"
         data_type: numeric
@@ -693,19 +637,16 @@ models:
           - dbt_utils.accepted_range:
               min_value: 0
               inclusive: true
-
       - name: collateral_type
         description: "Type of delegated collateral"
         data_type: text
         tests:
           - not_null
-
       - name: account_id
         description: "ID of the account"
         data_type: numeric
         tests:
           - not_null
-
       - name: reward_type
         description: "Type of reward (incentive or liquidation)"
         data_type: text
@@ -713,19 +654,16 @@ models:
           - not_null
           - accepted_values:
               values: ["liquidation", "incentive"]
-
       - name: distributor
         description: "Address of the reward distributor"
         data_type: text
         tests:
           - not_null
-
       - name: token_symbol
         description: "Symbol of the reward token"
         data_type: text
         tests:
           - not_null
-
       - name: amount
         description: "Amount of reward tokens"
         data_type: numeric
@@ -734,7 +672,6 @@ models:
           - dbt_utils.accepted_range:
               min_value: 0
               inclusive: true
-
       - name: price
         description: "Price of the reward token in USD"
         data_type: numeric
@@ -743,7 +680,6 @@ models:
           - dbt_utils.accepted_range:
               min_value: 0
               inclusive: true
-
       - name: amount_usd
         description: "USD value of the reward amount"
         data_type: numeric
@@ -752,3 +688,45 @@ models:
           - dbt_utils.accepted_range:
               min_value: 0
               inclusive: true
+  - name: fct_token_yields_arbitrum_mainnet
+    columns:
+      - name: ts
+        description: "Block timestamp"
+        data_type: timestamp with time zone
+        tests:
+          - not_null
+      - name: pool_id
+        description: "ID of the pool"
+        data_type: numeric
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              min_value: 0
+              inclusive: true
+      - name: collateral_type
+        description: "Type of delegated collateral"
+        data_type: text
+        tests:
+          - not_null
+      - name: exchange_rate
+        description: "Exchange rate of the collateral to the yield token"
+        data_type: numeric
+        tests:
+          - not_null
+      - name: hourly_exchange_rate_pnl
+        description: "Hourly exchange rate PnL"
+        data_type: numeric
+        tests:
+          - not_null
+      - name: apr_24h_underlying
+        data_type: numeric
+        tests:
+          - not_null
+      - name: apr_7d_underlying
+        data_type: numeric
+        tests:
+          - not_null
+      - name: apr_28d_underlying
+        data_type: numeric
+        tests:
+          - not_null

--- a/transformers/synthetix/models/marts/base/mainnet/core/schema.yml
+++ b/transformers/synthetix/models/marts/base/mainnet/core/schema.yml
@@ -698,63 +698,8 @@ models:
           - dbt_utils.accepted_range:
               min_value: 0
               inclusive: true
-  - name: fct_core_yield_metrics_base_mainnet
-    description: "Hourly yield metrics including exchange rates and trailing yield percentages"
-    columns:
-      - name: ts
-        description: "Block timestamp"
-        data_type: timestamp with time zone
-        tests:
-          - not_null
 
-      - name: pool_id
-        description: "ID of the pool"
-        data_type: numeric
-        tests:
-          - not_null
-          - dbt_utils.accepted_range:
-              min_value: 0
-              inclusive: true
-
-      - name: collateral_type
-        description: "Type of delegated collateral as an address"
-        data_type: text
-        tests:
-          - not_null
-
-      - name: exchange_rate
-        description: "Exchange rate between token and yield token (ie ETH and wstETH)"
-        data_type: numeric
-        tests:
-          - not_null
-          - dbt_utils.accepted_range:
-              min_value: 0
-
-      - name: hourly_exchange_rate_pnl
-        description: "Hourly change in exchange rate"
-        data_type: numeric
-        tests:
-          - not_null
-
-      - name: apr_24h_underlying
-        description: "Annualized yield percentage based on 24-hour average"
-        data_type: numeric
-        tests:
-          - not_null
-
-      - name: apr_7d_underlying
-        description: "Annualized yield percentage based on 7-day average"
-        data_type: numeric
-        tests:
-          - not_null
-
-      - name: apr_28d_underlying
-        description: "Annualized yield percentage based on 28-day average"
-        data_type: numeric
-        tests:
-          - not_null
-
-  - name: fct_core_reward_claims_base_mainnet
+  - name: fct_core_rewards_claimed_base_mainnet
     description: "Records of reward claims including token amounts and USD values"
     columns:
       - name: ts
@@ -762,7 +707,6 @@ models:
         data_type: timestamp with time zone
         tests:
           - not_null
-
       - name: pool_id
         description: "ID of the pool"
         data_type: numeric
@@ -771,19 +715,16 @@ models:
           - dbt_utils.accepted_range:
               min_value: 0
               inclusive: true
-
       - name: collateral_type
         description: "Type of delegated collateral"
         data_type: text
         tests:
           - not_null
-
       - name: account_id
         description: "ID of the account"
         data_type: numeric
         tests:
           - not_null
-
       - name: reward_type
         description: "Type of reward (incentive or liquidation)"
         data_type: text
@@ -791,19 +732,16 @@ models:
           - not_null
           - accepted_values:
               values: ["liquidation", "incentive"]
-
       - name: distributor
         description: "Address of the reward distributor"
         data_type: text
         tests:
           - not_null
-
       - name: token_symbol
         description: "Symbol of the reward token"
         data_type: text
         tests:
           - not_null
-
       - name: amount
         description: "Amount of reward tokens"
         data_type: numeric
@@ -812,7 +750,6 @@ models:
           - dbt_utils.accepted_range:
               min_value: 0
               inclusive: true
-
       - name: price
         description: "Price of the reward token in USD"
         data_type: numeric
@@ -821,7 +758,6 @@ models:
           - dbt_utils.accepted_range:
               min_value: 0
               inclusive: true
-
       - name: amount_usd
         description: "USD value of the reward amount"
         data_type: numeric
@@ -830,3 +766,46 @@ models:
           - dbt_utils.accepted_range:
               min_value: 0
               inclusive: true
+  - name: fct_token_yields_base_mainnet
+    columns:
+      - name: ts
+        description: "Block timestamp"
+        data_type: timestamp with time zone
+        tests:
+          - not_null
+      - name: pool_id
+        description: "ID of the pool"
+        data_type: numeric
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              min_value: 0
+              inclusive: true
+      - name: collateral_type
+        description: "Type of delegated collateral"
+        data_type: text
+        tests:
+          - not_null
+      - name: exchange_rate
+        description: "Exchange rate of the collateral to the yield token"
+        data_type: numeric
+        tests:
+          - not_null
+      - name: hourly_exchange_rate_pnl
+        description: "Hourly exchange rate PnL"
+        data_type: numeric
+        tests:
+          - not_null
+      - name: apr_24h_underlying
+        data_type: numeric
+        tests:
+          - not_null
+      - name: apr_7d_underlying
+        data_type: numeric
+        tests:
+          - not_null
+      - name: apr_28d_underlying
+        data_type: numeric
+        tests:
+          - not_null
+

--- a/transformers/synthetix/models/marts/eth/mainnet/core/schema.yml
+++ b/transformers/synthetix/models/marts/eth/mainnet/core/schema.yml
@@ -732,15 +732,15 @@ models:
           - dbt_utils.accepted_range:
               min_value: 0
               inclusive: true
-  - name: fct_core_yield_metrics_eth_mainnet
-    description: "Hourly yield metrics including exchange rates and trailing yield percentages"
+
+  - name: fct_core_rewards_claimed_eth_mainnet
+    description: "Records of reward claims including token amounts and USD values"
     columns:
       - name: ts
         description: "Block timestamp"
         data_type: timestamp with time zone
         tests:
           - not_null
-
       - name: pool_id
         description: "ID of the pool"
         data_type: numeric
@@ -749,42 +749,96 @@ models:
           - dbt_utils.accepted_range:
               min_value: 0
               inclusive: true
-
       - name: collateral_type
-        description: "Type of delegated collateral as an address"
+        description: "Type of delegated collateral"
         data_type: text
         tests:
           - not_null
-
-      - name: exchange_rate
-        description: "Exchange rate between token and yield token (ie ETH and wstETH)"
+      - name: account_id
+        description: "ID of the account"
+        data_type: numeric
+        tests:
+          - not_null
+      - name: reward_type
+        description: "Type of reward (incentive or liquidation)"
+        data_type: text
+        tests:
+          - not_null
+          - accepted_values:
+              values: ["liquidation", "incentive"]
+      - name: distributor
+        description: "Address of the reward distributor"
+        data_type: text
+        tests:
+          - not_null
+      - name: token_symbol
+        description: "Symbol of the reward token"
+        data_type: text
+        tests:
+          - not_null
+      - name: amount
+        description: "Amount of reward tokens"
         data_type: numeric
         tests:
           - not_null
           - dbt_utils.accepted_range:
               min_value: 0
               inclusive: true
-
+      - name: price
+        description: "Price of the reward token in USD"
+        data_type: numeric
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              min_value: 0
+              inclusive: true
+      - name: amount_usd
+        description: "USD value of the reward amount"
+        data_type: numeric
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              min_value: 0
+              inclusive: true
+  - name: fct_token_yields_eth_mainnet
+    columns:
+      - name: ts
+        description: "Block timestamp"
+        data_type: timestamp with time zone
+        tests:
+          - not_null
+      - name: pool_id
+        description: "ID of the pool"
+        data_type: numeric
+        tests:
+          - not_null
+          - dbt_utils.accepted_range:
+              min_value: 0
+              inclusive: true
+      - name: collateral_type
+        description: "Type of delegated collateral"
+        data_type: text
+        tests:
+          - not_null
+      - name: exchange_rate
+        description: "Exchange rate of the collateral to the yield token"
+        data_type: numeric
+        tests:
+          - not_null
       - name: hourly_exchange_rate_pnl
-        description: "Hourly change in exchange rate"
+        description: "Hourly exchange rate PnL"
         data_type: numeric
         tests:
           - not_null
-
       - name: apr_24h_underlying
-        description: "Annualized yield percentage based on 24-hour average"
         data_type: numeric
         tests:
           - not_null
-
       - name: apr_7d_underlying
-        description: "Annualized yield percentage based on 7-day average"
         data_type: numeric
         tests:
           - not_null
-
       - name: apr_28d_underlying
-        description: "Annualized yield percentage based on 28-day average"
         data_type: numeric
         tests:
           - not_null


### PR DESCRIPTION
- remove `fct_core_yield_metrics` (model doesn't exist anymore by that name) and replace with `fct_token_yields`
- add `fct_core_rewards_claimed` to Ethereum
- fix naming for `fct_core_rewards_claimed` for Base and Arbitrum