### PR TITLE
Transformers - Fix empty seed file

### DIFF
--- a/transformers/synthetix/dbt_project.yml
+++ b/transformers/synthetix/dbt_project.yml
@@ -282,4 +282,15 @@ models:
           +tags: "optimism_mainnet"
           +schema: optimism_mainnet
 seeds:
-  +schema: seeds
+  synthetix:
+    +schema: seeds
+    reward_distributors:
+      eth_mainnet_reward_distributors:
+        +column_types:
+          reward_type: text
+      base_mainnet_reward_distributors:
+        +column_types:
+          reward_type: text
+      arbitrum_mainnet_reward_distributors:
+        +column_types:
+          reward_type: text

--- a/transformers/synthetix/models/marts/eth/mainnet/core/schema.yml
+++ b/transformers/synthetix/models/marts/eth/mainnet/core/schema.yml
@@ -727,7 +727,6 @@ models:
         data_type: numeric
         tests:
           - not_null
-
   - name: fct_core_migration_hourly_eth_mainnet
     columns:
       - name: ts
@@ -756,7 +755,6 @@ models:
           - dbt_utils.accepted_range:
               min_value: 0
               inclusive: true
-
   - name: fct_core_rewards_claimed_eth_mainnet
     description: "Records of reward claims including token amounts and USD values"
     columns:
@@ -866,79 +864,3 @@ models:
         data_type: numeric
         tests:
           - not_null
-  - name: fct_core_reward_claims_eth_mainnet
-    description: "Records of reward claims including token amounts and USD values"
-    columns:
-      - name: ts
-        description: "Block timestamp"
-        data_type: timestamp with time zone
-        tests:
-          - not_null
-
-      - name: pool_id
-        description: "ID of the pool"
-        data_type: numeric
-        tests:
-          - not_null
-          - dbt_utils.accepted_range:
-              min_value: 0
-              inclusive: true
-
-      - name: collateral_type
-        description: "Type of delegated collateral"
-        data_type: text
-        tests:
-          - not_null
-
-      - name: account_id
-        description: "ID of the account"
-        data_type: numeric
-        tests:
-          - not_null
-
-      - name: reward_type
-        description: "Type of reward (incentive or liquidation)"
-        data_type: text
-        tests:
-          - not_null
-          - accepted_values:
-              values: ["liquidation", "incentive"]
-
-      - name: distributor
-        description: "Address of the reward distributor"
-        data_type: text
-        tests:
-          - not_null
-
-      - name: token_symbol
-        description: "Symbol of the reward token"
-        data_type: text
-        tests:
-          - not_null
-
-      - name: amount
-        description: "Amount of reward tokens"
-        data_type: numeric
-        tests:
-          - not_null
-          - dbt_utils.accepted_range:
-              min_value: 0
-              inclusive: true
-
-      - name: price
-        description: "Price of the reward token in USD"
-        data_type: numeric
-        tests:
-          - not_null
-          - dbt_utils.accepted_range:
-              min_value: 0
-              inclusive: true
-
-      - name: amount_usd
-        description: "USD value of the reward amount"
-        data_type: numeric
-        tests:
-          - not_null
-          - dbt_utils.accepted_range:
-              min_value: 0
-              inclusive: true


### PR DESCRIPTION
The `rewards_distributors` seed is empty for Ethereum, which causes a database error during the scheduled models tests task. The `reward_type` field has to be explicitly casted as `text`, as we are doing string validation on it downstream.