### PR TITLE
Transformers - Add PoL Stats Models

### DIFF
--- a/transformers/synthetix/dbt_project.yml
+++ b/transformers/synthetix/dbt_project.yml
@@ -225,6 +225,9 @@ models:
         mainnet:
           +tags: "eth_mainnet"
           +schema: raw_eth_mainnet
+          core:
+            core_vault_collateral_eth_mainnet:
+              +enabled: true
       base:
         +enabled: "{{ target.name != 'prod-op' }}"
         mainnet:
@@ -260,6 +263,8 @@ models:
         mainnet:
           +tags: "eth_mainnet"
           +schema: eth_mainnet
+          prices:
+            +enabled: true
       base:
         +enabled: "{{ target.name != 'prod-op' }}"
         mainnet:

--- a/transformers/synthetix/models/marts/base/mainnet/core/fct_pol_stats_base_mainnet.sql
+++ b/transformers/synthetix/models/marts/base/mainnet/core/fct_pol_stats_base_mainnet.sql
@@ -1,0 +1,166 @@
+with delegation_changes as (
+    select
+        block_timestamp as ts,
+        account_id,
+        {{ convert_wei('amount') }}
+        - LAG({{ convert_wei('amount') }}, 1, 0) over (
+            partition by
+                account_id,
+                pool_id,
+                collateral_type
+            order by
+                block_timestamp
+        ) as change_in_amount
+    from
+        {{ ref('core_delegation_updated_base_mainnet') }}
+    where pool_id = 8
+),
+
+delegated as (
+    select
+        ts,
+        account_id,
+        change_in_amount,
+        sum(change_in_amount) over (order by ts) as cumulative_token_amount
+    from delegation_changes
+),
+
+prices as (
+    select
+        ts,
+        price
+    from {{ ref('fct_prices_hourly_eth_mainnet') }}
+    where market_symbol = 'SNX'
+),
+
+hourly_aggregates as (
+    select
+        date_trunc('hour', delegated.ts) as hour_ts,
+        sum(change_in_amount) as hourly_change_in_amount,
+        count(distinct account_id) as hourly_account_count,
+        last(prices_hourly.price) as hourly_price
+    from delegated
+    left join (
+        select
+            date_trunc('hour', ts) as ts,
+            last(price) as price
+        from prices
+        group by date_trunc('hour', ts)
+    ) as prices_hourly
+        on date_trunc('hour', delegated.ts) = prices_hourly.ts
+    group by date_trunc('hour', delegated.ts), prices_hourly.price
+),
+
+daily_aggregates as (
+    select
+        date_trunc('day', delegated.ts) as day_ts,
+        sum(change_in_amount) as daily_change_in_amount,
+        count(distinct account_id) as daily_account_count,
+        last(prices_daily.price) as daily_price
+    from delegated
+    left join (
+        select
+            date_trunc('day', ts) as ts,
+            last(price) as price
+        from prices
+        group by date_trunc('day', ts)
+    ) as prices_daily
+        on date_trunc('day', delegated.ts) = prices_daily.ts
+    group by date_trunc('day', delegated.ts), prices_daily.price
+),
+
+weekly_aggregates as (
+    select
+        date_trunc('week', delegated.ts) as week_ts,
+        sum(change_in_amount) as weekly_change_in_amount,
+        count(distinct account_id) as weekly_account_count,
+        prices_weekly.price as weekly_price
+    from delegated
+    left join (
+        select
+            date_trunc('week', ts) as ts,
+            last(price) as price
+        from prices
+        group by date_trunc('week', ts)
+    ) as prices_weekly
+        on date_trunc('week', delegated.ts) = prices_weekly.ts
+    group by date_trunc('week', delegated.ts), prices_weekly.price
+),
+
+monthly_aggregates as (
+    select
+        date_trunc('month', delegated.ts) as month_ts,
+        sum(change_in_amount) as monthly_change_in_amount,
+        count(distinct account_id) as monthly_account_count,
+        last(prices_monthly.price) as monthly_price
+    from delegated
+    left join (
+        select
+            date_trunc('month', ts) as ts,
+            last(price) as price
+        from prices
+        group by date_trunc('month', ts)
+    ) as prices_monthly
+        on date_trunc('month', delegated.ts) = prices_monthly.ts
+    group by date_trunc('month', delegated.ts), prices_monthly.price
+),
+
+delegation_with_prices as (
+    select
+        delegated.ts,
+        account_id,
+        change_in_amount,
+        change_in_amount * hourly_price as change_in_usd,
+        cumulative_token_amount,
+        cumulative_token_amount * hourly_price as cumulative_usd,
+        hourly_change_in_amount,
+        hourly_change_in_amount * hourly_price as hourly_change_in_usd,
+        hourly_price as hourly_price,
+        hourly_account_count,
+        daily_change_in_amount,
+        daily_change_in_amount * daily_price as daily_change_in_usd,
+        daily_price as daily_price,
+        daily_account_count,
+        weekly_change_in_amount,
+        weekly_change_in_amount * weekly_price as weekly_change_in_usd,
+        weekly_price as weekly_price,
+        weekly_account_count,
+        monthly_change_in_amount,
+        monthly_change_in_amount * monthly_price as monthly_change_in_usd,
+        monthly_price as monthly_price,
+        monthly_account_count
+    from delegated
+    left join hourly_aggregates h
+        on date_trunc('hour', delegated.ts) = h.hour_ts
+    left join daily_aggregates d
+        on date_trunc('day', delegated.ts) = d.day_ts
+    left join weekly_aggregates w
+        on date_trunc('week', delegated.ts) = w.week_ts
+    left join monthly_aggregates m
+        on date_trunc('month', delegated.ts) = m.month_ts
+)
+
+select
+    ts,
+    account_id,
+    change_in_amount,
+    change_in_usd,
+    cumulative_token_amount,
+    cumulative_usd,
+    hourly_change_in_amount,
+    hourly_change_in_usd,
+    hourly_price,
+    hourly_account_count,
+    daily_change_in_amount,
+    daily_change_in_usd,
+    daily_price,
+    daily_account_count,
+    weekly_change_in_amount,
+    weekly_change_in_usd,
+    weekly_price,
+    weekly_account_count,
+    monthly_change_in_amount,
+    monthly_change_in_usd,
+    monthly_account_count,
+    monthly_price
+from delegation_with_prices

--- a/transformers/synthetix/models/marts/base/mainnet/core/schema.yml
+++ b/transformers/synthetix/models/marts/base/mainnet/core/schema.yml
@@ -848,4 +848,51 @@ models:
         data_type: numeric
         tests:
           - not_null
+  - name: fct_pol_stats_base_mainnet
+    columns:
+      - name: ts
+        data_type: timestamp with time zone
+      - name: account_id
+        data_type: text
+      - name: change_in_amount
+        data_type: numeric
+      - name: change_in_usd
+        data_type: numeric
+      - name: cumulative_token_amount
+        data_type: numeric
+      - name: cumulative_usd
+        data_type: numeric
+      - name: hourly_change_in_amount
+        data_type: numeric
+      - name: hourly_change_in_usd
+        data_type: numeric
+      - name: hourly_price
+        data_type: numeric
+      - name: hourly_account_count
+        data_type: numeric
+      - name: daily_change_in_amount
+        data_type: numeric
+      - name: daily_change_in_usd
+        data_type: numeric
+      - name: daily_price
+        data_type: numeric
+      - name: daily_account_count
+        data_type: numeric
+      - name: weekly_change_in_amount
+        data_type: numeric
+      - name: weekly_change_in_usd
+        data_type: numeric
+      - name: weekly_price
+        data_type: numeric
+      - name: weekly_account_count
+        data_type: numeric
+      - name: monthly_change_in_amount
+        data_type: numeric
+      - name: monthly_change_in_usd
+        data_type: numeric
+      - name: monthly_account_count
+        data_type: numeric
+      - name: monthly_price
+        data_type: numeric
+
 

--- a/transformers/synthetix/models/marts/eth/mainnet/core/fct_pol_stats_eth_mainnet.sql
+++ b/transformers/synthetix/models/marts/eth/mainnet/core/fct_pol_stats_eth_mainnet.sql
@@ -1,0 +1,166 @@
+with delegation_changes as (
+    select
+        block_timestamp as ts,
+        account_id,
+        {{ convert_wei('amount') }}
+        - LAG({{ convert_wei('amount') }}, 1, 0) over (
+            partition by
+                account_id,
+                pool_id,
+                collateral_type
+            order by
+                block_timestamp
+        ) as change_in_amount
+    from
+        {{ ref('core_delegation_updated_eth_mainnet') }}
+    where pool_id = 8
+),
+
+delegated as (
+    select
+        ts,
+        account_id,
+        change_in_amount,
+        sum(change_in_amount) over (order by ts) as cumulative_token_amount
+    from delegation_changes
+),
+
+prices as (
+    select
+        ts,
+        price
+    from {{ ref('fct_prices_hourly_eth_mainnet') }}
+    where market_symbol = 'SNX'
+),
+
+hourly_aggregates as (
+    select
+        date_trunc('hour', delegated.ts) as hour_ts,
+        sum(change_in_amount) as hourly_change_in_amount,
+        count(distinct account_id) as hourly_account_count,
+        last(prices_hourly.price) as hourly_price
+    from delegated
+    left join (
+        select
+            date_trunc('hour', ts) as ts,
+            last(price) as price
+        from prices
+        group by date_trunc('hour', ts)
+    ) as prices_hourly
+        on date_trunc('hour', delegated.ts) = prices_hourly.ts
+    group by date_trunc('hour', delegated.ts), prices_hourly.price
+),
+
+daily_aggregates as (
+    select
+        date_trunc('day', delegated.ts) as day_ts,
+        sum(change_in_amount) as daily_change_in_amount,
+        count(distinct account_id) as daily_account_count,
+        last(prices_daily.price) as daily_price
+    from delegated
+    left join (
+        select
+            date_trunc('day', ts) as ts,
+            last(price) as price
+        from prices
+        group by date_trunc('day', ts)
+    ) as prices_daily
+        on date_trunc('day', delegated.ts) = prices_daily.ts
+    group by date_trunc('day', delegated.ts), prices_daily.price
+),
+
+weekly_aggregates as (
+    select
+        date_trunc('week', delegated.ts) as week_ts,
+        sum(change_in_amount) as weekly_change_in_amount,
+        count(distinct account_id) as weekly_account_count,
+        prices_weekly.price as weekly_price
+    from delegated
+    left join (
+        select
+            date_trunc('week', ts) as ts,
+            last(price) as price
+        from prices
+        group by date_trunc('week', ts)
+    ) as prices_weekly
+        on date_trunc('week', delegated.ts) = prices_weekly.ts
+    group by date_trunc('week', delegated.ts), prices_weekly.price
+),
+
+monthly_aggregates as (
+    select
+        date_trunc('month', delegated.ts) as month_ts,
+        sum(change_in_amount) as monthly_change_in_amount,
+        count(distinct account_id) as monthly_account_count,
+        last(prices_monthly.price) as monthly_price
+    from delegated
+    left join (
+        select
+            date_trunc('month', ts) as ts,
+            last(price) as price
+        from prices
+        group by date_trunc('month', ts)
+    ) as prices_monthly
+        on date_trunc('month', delegated.ts) = prices_monthly.ts
+    group by date_trunc('month', delegated.ts), prices_monthly.price
+),
+
+delegation_with_prices as (
+    select
+        delegated.ts,
+        account_id,
+        change_in_amount,
+        change_in_amount * hourly_price as change_in_usd,
+        cumulative_token_amount,
+        cumulative_token_amount * hourly_price as cumulative_usd,
+        hourly_change_in_amount,
+        hourly_change_in_amount * hourly_price as hourly_change_in_usd,
+        hourly_price as hourly_price,
+        hourly_account_count,
+        daily_change_in_amount,
+        daily_change_in_amount * daily_price as daily_change_in_usd,
+        daily_price as daily_price,
+        daily_account_count,
+        weekly_change_in_amount,
+        weekly_change_in_amount * weekly_price as weekly_change_in_usd,
+        weekly_price as weekly_price,
+        weekly_account_count,
+        monthly_change_in_amount,
+        monthly_change_in_amount * monthly_price as monthly_change_in_usd,
+        monthly_price as monthly_price,
+        monthly_account_count
+    from delegated
+    left join hourly_aggregates h
+        on date_trunc('hour', delegated.ts) = h.hour_ts
+    left join daily_aggregates d
+        on date_trunc('day', delegated.ts) = d.day_ts
+    left join weekly_aggregates w
+        on date_trunc('week', delegated.ts) = w.week_ts
+    left join monthly_aggregates m
+        on date_trunc('month', delegated.ts) = m.month_ts
+)
+
+select
+    ts,
+    account_id,
+    change_in_amount,
+    change_in_usd,
+    cumulative_token_amount,
+    cumulative_usd,
+    hourly_change_in_amount,
+    hourly_change_in_usd,
+    hourly_price,
+    hourly_account_count,
+    daily_change_in_amount,
+    daily_change_in_usd,
+    daily_price,
+    daily_account_count,
+    weekly_change_in_amount,
+    weekly_change_in_usd,
+    weekly_price,
+    weekly_account_count,
+    monthly_change_in_amount,
+    monthly_change_in_usd,
+    monthly_account_count,
+    monthly_price
+from delegation_with_prices

--- a/transformers/synthetix/models/marts/eth/mainnet/core/schema.yml
+++ b/transformers/synthetix/models/marts/eth/mainnet/core/schema.yml
@@ -864,3 +864,50 @@ models:
         data_type: numeric
         tests:
           - not_null
+  - name: fct_pol_stats_eth_mainnet
+    columns:
+      - name: ts
+        data_type: timestamp with time zone
+      - name: account_id
+        data_type: text
+      - name: change_in_amount
+        data_type: numeric
+      - name: change_in_usd
+        data_type: numeric
+      - name: cumulative_token_amount
+        data_type: numeric
+      - name: cumulative_usd
+        data_type: numeric
+      - name: hourly_change_in_amount
+        data_type: numeric
+      - name: hourly_change_in_usd
+        data_type: numeric
+      - name: hourly_price
+        data_type: numeric
+      - name: hourly_account_count
+        data_type: numeric
+      - name: daily_change_in_amount
+        data_type: numeric
+      - name: daily_change_in_usd
+        data_type: numeric
+      - name: daily_price
+        data_type: numeric
+      - name: daily_account_count
+        data_type: numeric
+      - name: weekly_change_in_amount
+        data_type: numeric
+      - name: weekly_change_in_usd
+        data_type: numeric
+      - name: weekly_price
+        data_type: numeric
+      - name: weekly_account_count
+        data_type: numeric
+      - name: monthly_change_in_amount
+        data_type: numeric
+      - name: monthly_change_in_usd
+        data_type: numeric
+      - name: monthly_account_count
+        data_type: numeric
+      - name: monthly_price
+        data_type: numeric
+

--- a/transformers/synthetix/models/marts/optimism/mainnet/core/fct_pol_stats_optimism_mainnet.sql
+++ b/transformers/synthetix/models/marts/optimism/mainnet/core/fct_pol_stats_optimism_mainnet.sql
@@ -1,0 +1,166 @@
+with delegation_changes as (
+    select
+        block_timestamp as ts,
+        account_id,
+        {{ convert_wei('amount') }}
+        - LAG({{ convert_wei('amount') }}, 1, 0) over (
+            partition by
+                account_id,
+                pool_id,
+                collateral_type
+            order by
+                block_timestamp
+        ) as change_in_amount
+    from
+        {{ ref('core_delegation_updated_optimism_mainnet') }}
+    where pool_id = 8
+),
+
+delegated as (
+    select
+        ts,
+        account_id,
+        change_in_amount,
+        sum(change_in_amount) over (order by ts) as cumulative_token_amount
+    from delegation_changes
+),
+
+prices as (
+    select
+        ts,
+        price
+    from {{ ref('fct_prices_hourly_eth_mainnet') }}
+    where market_symbol = 'SNX'
+),
+
+hourly_aggregates as (
+    select
+        date_trunc('hour', delegated.ts) as hour_ts,
+        sum(change_in_amount) as hourly_change_in_amount,
+        count(distinct account_id) as hourly_account_count,
+        last(prices_hourly.price) as hourly_price
+    from delegated
+    left join (
+        select
+            date_trunc('hour', ts) as ts,
+            last(price) as price
+        from prices
+        group by date_trunc('hour', ts)
+    ) as prices_hourly
+        on date_trunc('hour', delegated.ts) = prices_hourly.ts
+    group by date_trunc('hour', delegated.ts), prices_hourly.price
+),
+
+daily_aggregates as (
+    select
+        date_trunc('day', delegated.ts) as day_ts,
+        sum(change_in_amount) as daily_change_in_amount,
+        count(distinct account_id) as daily_account_count,
+        last(prices_daily.price) as daily_price
+    from delegated
+    left join (
+        select
+            date_trunc('day', ts) as ts,
+            last(price) as price
+        from prices
+        group by date_trunc('day', ts)
+    ) as prices_daily
+        on date_trunc('day', delegated.ts) = prices_daily.ts
+    group by date_trunc('day', delegated.ts), prices_daily.price
+),
+
+weekly_aggregates as (
+    select
+        date_trunc('week', delegated.ts) as week_ts,
+        sum(change_in_amount) as weekly_change_in_amount,
+        count(distinct account_id) as weekly_account_count,
+        prices_weekly.price as weekly_price
+    from delegated
+    left join (
+        select
+            date_trunc('week', ts) as ts,
+            last(price) as price
+        from prices
+        group by date_trunc('week', ts)
+    ) as prices_weekly
+        on date_trunc('week', delegated.ts) = prices_weekly.ts
+    group by date_trunc('week', delegated.ts), prices_weekly.price
+),
+
+monthly_aggregates as (
+    select
+        date_trunc('month', delegated.ts) as month_ts,
+        sum(change_in_amount) as monthly_change_in_amount,
+        count(distinct account_id) as monthly_account_count,
+        last(prices_monthly.price) as monthly_price
+    from delegated
+    left join (
+        select
+            date_trunc('month', ts) as ts,
+            last(price) as price
+        from prices
+        group by date_trunc('month', ts)
+    ) as prices_monthly
+        on date_trunc('month', delegated.ts) = prices_monthly.ts
+    group by date_trunc('month', delegated.ts), prices_monthly.price
+),
+
+delegation_with_prices as (
+    select
+        delegated.ts,
+        account_id,
+        change_in_amount,
+        change_in_amount * hourly_price as change_in_usd,
+        cumulative_token_amount,
+        cumulative_token_amount * hourly_price as cumulative_usd,
+        hourly_change_in_amount,
+        hourly_change_in_amount * hourly_price as hourly_change_in_usd,
+        hourly_price as hourly_price,
+        hourly_account_count,
+        daily_change_in_amount,
+        daily_change_in_amount * daily_price as daily_change_in_usd,
+        daily_price as daily_price,
+        daily_account_count,
+        weekly_change_in_amount,
+        weekly_change_in_amount * weekly_price as weekly_change_in_usd,
+        weekly_price as weekly_price,
+        weekly_account_count,
+        monthly_change_in_amount,
+        monthly_change_in_amount * monthly_price as monthly_change_in_usd,
+        monthly_price as monthly_price,
+        monthly_account_count
+    from delegated
+    left join hourly_aggregates h
+        on date_trunc('hour', delegated.ts) = h.hour_ts
+    left join daily_aggregates d
+        on date_trunc('day', delegated.ts) = d.day_ts
+    left join weekly_aggregates w
+        on date_trunc('week', delegated.ts) = w.week_ts
+    left join monthly_aggregates m
+        on date_trunc('month', delegated.ts) = m.month_ts
+)
+
+select
+    ts,
+    account_id,
+    change_in_amount,
+    change_in_usd,
+    cumulative_token_amount,
+    cumulative_usd,
+    hourly_change_in_amount,
+    hourly_change_in_usd,
+    hourly_price,
+    hourly_account_count,
+    daily_change_in_amount,
+    daily_change_in_usd,
+    daily_price,
+    daily_account_count,
+    weekly_change_in_amount,
+    weekly_change_in_usd,
+    weekly_price,
+    weekly_account_count,
+    monthly_change_in_amount,
+    monthly_change_in_usd,
+    monthly_account_count,
+    monthly_price
+from delegation_with_prices

--- a/transformers/synthetix/models/marts/optimism/mainnet/core/schema.yml
+++ b/transformers/synthetix/models/marts/optimism/mainnet/core/schema.yml
@@ -14,3 +14,49 @@ models:
           - dbt_utils.accepted_range:
               min_value: 0
               inclusive: true
+  - name: fct_pol_stats_optimism_mainnet
+    columns:
+      - name: ts
+        data_type: timestamp with time zone
+      - name: account_id
+        data_type: text
+      - name: change_in_amount
+        data_type: numeric
+      - name: change_in_usd
+        data_type: numeric
+      - name: cumulative_token_amount
+        data_type: numeric
+      - name: cumulative_usd
+        data_type: numeric
+      - name: hourly_change_in_amount
+        data_type: numeric
+      - name: hourly_change_in_usd
+        data_type: numeric
+      - name: hourly_price
+        data_type: numeric
+      - name: hourly_account_count
+        data_type: numeric
+      - name: daily_change_in_amount
+        data_type: numeric
+      - name: daily_change_in_usd
+        data_type: numeric
+      - name: daily_price
+        data_type: numeric
+      - name: daily_account_count
+        data_type: numeric
+      - name: weekly_change_in_amount
+        data_type: numeric
+      - name: weekly_change_in_usd
+        data_type: numeric
+      - name: weekly_price
+        data_type: numeric
+      - name: weekly_account_count
+        data_type: numeric
+      - name: monthly_change_in_amount
+        data_type: numeric
+      - name: monthly_change_in_usd
+        data_type: numeric
+      - name: monthly_account_count
+        data_type: numeric
+      - name: monthly_price
+        data_type: numeric


### PR DESCRIPTION
Added PoL Hourly/Daily/Weekly/Monthly Stats Models in the `transformers` dbt service.

- All the models use `fct_eth_prices_hourly` model as it has hourly SNX prices
- The prices for the hourly/daily/weekly/monthly aggs are the last price in that time window (e.g. last price in the month for the monthly window)